### PR TITLE
[#45] 프로젝트 팀 목록 조회 및 팀 상세 조회 

### DIFF
--- a/src/main/java/com/kcc/pms/domain/team/controller/TeamController.java
+++ b/src/main/java/com/kcc/pms/domain/team/controller/TeamController.java
@@ -1,0 +1,30 @@
+package com.kcc.pms.domain.team.controller;
+
+import com.kcc.pms.domain.team.model.dto.TeamMemberResponseDto;
+import com.kcc.pms.domain.team.model.dto.TeamResponseDto;
+import com.kcc.pms.domain.team.service.TeamService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import java.util.List;
+
+@Controller
+@RequiredArgsConstructor
+public class TeamController {
+    private final TeamService teamService;
+
+    @GetMapping("/teams")
+    @ResponseBody
+    public List<TeamResponseDto> getTeamList(@RequestParam("projectNo") Long projectNo) {
+        return teamService.getTeamList(projectNo);
+    }
+
+    @GetMapping("/members")
+    @ResponseBody
+    public List<TeamMemberResponseDto> getMemberList(@RequestParam("teamNo") Long teamNo) {
+        return teamService.getTeamMember(teamNo);
+    }
+}

--- a/src/main/java/com/kcc/pms/domain/team/mapper/TeamMapper.java
+++ b/src/main/java/com/kcc/pms/domain/team/mapper/TeamMapper.java
@@ -1,0 +1,13 @@
+package com.kcc.pms.domain.team.mapper;
+
+import com.kcc.pms.domain.team.model.dto.TeamMemberResponseDto;
+import com.kcc.pms.domain.team.model.dto.TeamResponseDto;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+
+@Mapper
+public interface TeamMapper {
+    List<TeamResponseDto> getTeamList(Long projectNo);
+    List<TeamMemberResponseDto> getTeamMember(Long teamNo);
+}

--- a/src/main/java/com/kcc/pms/domain/team/model/dto/TeamMemberResponseDto.java
+++ b/src/main/java/com/kcc/pms/domain/team/model/dto/TeamMemberResponseDto.java
@@ -1,0 +1,27 @@
+package com.kcc.pms.domain.team.model.dto;
+
+import com.kcc.pms.domain.team.model.vo.Team;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+public class TeamMemberResponseDto implements Serializable {
+    private Long id;
+    private String memberName;
+    private String auth;
+    private String groupName;
+    private String position;
+    private String preStartDate;
+    private String preEndDate;
+    private String startDate;
+    private String endDate;
+    private String tech;
+    private String email;
+    private String phoneNo;
+    List<Team> connectTeams = new ArrayList<>();
+}

--- a/src/main/java/com/kcc/pms/domain/team/model/dto/TeamResponseDto.java
+++ b/src/main/java/com/kcc/pms/domain/team/model/dto/TeamResponseDto.java
@@ -1,0 +1,21 @@
+package com.kcc.pms.domain.team.model.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+public class TeamResponseDto implements Serializable {
+    private Integer key; //fancytree는 key로 고유값 구별
+    private String title; //fancytree는 title로 텍스트 표시
+    private String teamDescription;
+    private String parentTeamName;
+    private Integer totalCount;
+    private String systemName;
+    private Integer parentId;
+    private List<TeamResponseDto> children = new ArrayList<>();
+}

--- a/src/main/java/com/kcc/pms/domain/team/model/vo/Team.java
+++ b/src/main/java/com/kcc/pms/domain/team/model/vo/Team.java
@@ -1,0 +1,13 @@
+package com.kcc.pms.domain.team.model.vo;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.io.Serializable;
+
+@Getter
+@Setter
+public class Team implements Serializable {
+    private Long teamNo;
+    private String teamName;
+}

--- a/src/main/java/com/kcc/pms/domain/team/service/TeamService.java
+++ b/src/main/java/com/kcc/pms/domain/team/service/TeamService.java
@@ -1,0 +1,11 @@
+package com.kcc.pms.domain.team.service;
+
+import com.kcc.pms.domain.team.model.dto.TeamMemberResponseDto;
+import com.kcc.pms.domain.team.model.dto.TeamResponseDto;
+
+import java.util.List;
+
+public interface TeamService {
+    List<TeamResponseDto> getTeamList(Long projectNo);
+    List<TeamMemberResponseDto> getTeamMember(Long teamNo);
+}

--- a/src/main/java/com/kcc/pms/domain/team/service/TeamServiceImpl.java
+++ b/src/main/java/com/kcc/pms/domain/team/service/TeamServiceImpl.java
@@ -1,0 +1,52 @@
+package com.kcc.pms.domain.team.service;
+
+import com.kcc.pms.domain.member.model.dto.GroupResponseDto;
+import com.kcc.pms.domain.team.mapper.TeamMapper;
+import com.kcc.pms.domain.team.model.dto.TeamMemberResponseDto;
+import com.kcc.pms.domain.team.model.dto.TeamResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class TeamServiceImpl implements TeamService{
+    private final TeamMapper mapper;
+
+    @Override
+    public List<TeamResponseDto> getTeamList(Long projectNo) {
+        return buildTree(mapper.getTeamList(projectNo));
+    }
+
+    @Override
+    public List<TeamMemberResponseDto> getTeamMember(Long teamNo) {
+        return mapper.getTeamMember(teamNo);
+    }
+
+    public List<TeamResponseDto> buildTree(List<TeamResponseDto> nodeList) {
+        Map<Integer, TeamResponseDto> nodeMap = new HashMap<>();
+
+        for (TeamResponseDto node : nodeList) {
+            nodeMap.put(node.getKey(), node);
+        }
+
+        // 트리 구조로 변환
+        List<TeamResponseDto> rootNodes = new ArrayList<>();
+        for (TeamResponseDto node : nodeMap.values()) {
+            if (node.getParentId() == null) {
+                rootNodes.add(node);
+            } else {
+                TeamResponseDto parent = nodeMap.get(node.getParentId()); //부모 존재 시 부모 노드에 자기자신 추가
+                if (parent != null) {
+                    parent.getChildren().add(node);
+                }
+            }
+        }
+
+        return rootNodes;
+    }
+}

--- a/src/main/resources/mapper/TeamMapper.xml
+++ b/src/main/resources/mapper/TeamMapper.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- mapper DTD 선언 -->
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.kcc.pms.domain.team.mapper.TeamMapper">
+    <cache />
+
+    <select id="getTeamList" resultType="com.kcc.pms.domain.team.model.dto.TeamResponseDto">
+        SELECT t.tm_no as key,
+               t.tm_nm as title,
+               t.tm_cont as teamDescription,
+               pt.tm_nm as parentTeamName,
+               NVL(pm.cnt, 0) as totalCount,
+               s.sys_ttl as systemName,
+               t.par_tm_no as parentId,
+               t.order_no
+        FROM team t,
+             system s,
+             team pt,
+             (SELECT tm_no, COUNT(*) cnt
+              FROM projectmember
+              GROUP BY tm_no) pm
+        WHERE t.sys_no = s.sys_no(+)
+          AND t.par_tm_no = pt.tm_no(+)
+          AND t.tm_no = pm.tm_no(+)
+          AND t.prj_no = #{projectNo}
+        ORDER BY NVL(t.par_tm_no, t.tm_no), t.order_no
+    </select>
+
+
+
+
+    <resultMap id="teamMemberDetail" type="com.kcc.pms.domain.team.model.dto.TeamMemberResponseDto">
+        <id column="MEM_NO" property="id" />
+        <result column="MEM_NM" property="memberName" />
+        <result column="AUTH" property="auth" /> <!-- 프로젝트 권한 -->
+        <result column="GRP_NM" property="groupName" /> <!-- 소속 그룹 -->
+        <result column="POSITION" property="position" /> <!-- 직위 -->
+        <result column="PRE_START_DT" property="preStartDate" />
+        <result column="PRE_END_DT" property="preEndDate" />
+        <result column="START_DT" property="startDate" />
+        <result column="END_DT" property="endDate" />
+        <result column="TECH" property="tech" /> <!-- 기술 등급 -->
+        <result column="EMAIL" property="email" />
+        <result column="PHONE_NO" property="phoneNo" />
+
+        <collection property="connectTeams" resultMap="connectTeams"/>
+    </resultMap>
+
+    <resultMap id="connectTeams" type="com.kcc.pms.domain.team.model.vo.Team">
+        <result column="TM_NO" property="teamNo" />
+        <result column="TM_NM" property="teamName" />
+    </resultMap>
+
+    <select id="getTeamMember" resultMap="teamMemberDetail">
+        SELECT m.mem_no,
+               m.mem_nm,
+               auth.cd_dtl_nm as AUTH,
+               gr.grp_nm,
+               pos.cd_dtl_nm as POSITION,
+               pm.pre_start_dt,
+               pm.pre_end_dt,
+               pm.start_dt,
+               pm.end_dt,
+               tech.cd_dtl_nm as TECH,
+               m.email,
+               m.phone_no,
+               pmt.tm_no,
+               pmt.tm_nm
+        FROM projectmember pm,
+             member m,
+             usergroup gr,
+             codedetail auth,
+             codedetail pos,
+             codedetail tech,
+             (SELECT t.tm_no, t.tm_nm, pm.mem_no
+              FROM team t, projectmember pm
+              WHERE t.tm_no = pm.tm_no
+                AND t.par_tm_no IS NOT NULL
+             ) pmt
+        WHERE pm.prj_auth_cd = auth.cd_dtl_no AND
+            m.tech_grd_cd = tech.cd_dtl_no AND
+            m.pos_nm = pos.cd_dtl_no AND
+            pm.mem_no = m.mem_no AND
+            m.grp_no = gr.grp_no AND
+            pm.mem_no = pmt.mem_no AND
+            pm.tm_no = #{teamNo}
+    </select>
+</mapper>

--- a/src/main/webapp/WEB-INF/views/member/list.jsp
+++ b/src/main/webapp/WEB-INF/views/member/list.jsp
@@ -20,10 +20,18 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jstree/3.3.12/jstree.search.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jstree/3.3.12/jstree.dnd.min.js"></script>
 
+
+<link href="https://cdnjs.cloudflare.com/ajax/libs/jquery.fancytree/2.38.1/skin-win8/ui.fancytree.min.css" rel="stylesheet">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.fancytree/2.38.1/jquery.fancytree-all-deps.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.fancytree/2.38.1/modules/jquery.fancytree.table.min.js"></script>
+<script src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.fancytree/2.38.1/modules/jquery.fancytree.filter.min.js"></script>
+
 <link rel="stylesheet" href="../../../resources/member/css/list.css">
 <link rel="stylesheet" href="../../../resources/member/css/ax5grid.css">
 
-<!-- 콘텐츠 영역 -->
+
 <main class="content" id="content">
     <div class="main_content">
 
@@ -33,7 +41,21 @@
 
         <div class="container1">
             <div class="left-section">
-                <table class="sidebar-table1">
+                <button id="btnResetSearch" style="font-size: 16px; padding: 0px; display: none">&times;</button>
+                <!-- 검색 바-->
+                <div style="position: sticky; bottom: 0; background-color: #f5f5f5; padding: 3px; display: flex; justify-content: space-between; align-items: center;">
+                    <input type="text" name="search" placeholder="팀명 겸색..." style="font-size: 12px; padding: 5px; width: 40%;">
+                    <div class="btn-group" style="display: flex; align-items: center;">
+                        <span id="matches" style="font-size: 12px; margin-right: 10px;"></span>
+                        <button id="btnEdit" style="font-size: 14px; padding: 5px;">순서 편집</button>
+                    </div>
+                </div>
+                <table id="tree-table" class="fancytree-ext-table">
+                    <colgroup>
+                        <col width="300px">
+                        <col width="200px">
+                        <col width="100px">
+                    </colgroup>
                     <thead>
                     <tr>
                         <th>팀명</th>
@@ -41,10 +63,7 @@
                         <th>인원수</th>
                     </tr>
                     </thead>
-                    <tbody>
-
-
-                    </tbody>
+                    <tbody></tbody>
                 </table>
             </div>
 
@@ -55,7 +74,7 @@
                     <div class="team-overview-title">
                         <div class="team-title">팀 개요</div>
                         <div class="btn-group">
-                            <button class="" onclick="openGroupPopup()">그룹등록</button>
+                            <button class="">그룹등록</button>
                             <button class="">수정</button>
                             <button class="">삭제</button>
                         </div>
@@ -64,19 +83,19 @@
                     <table class="overview-table">
                         <tr>
                             <td class="text-align-right">팀명</td>
-                            <td colspan="3">개발팀</td>
+                            <td colspan="3" id="team-name">-</td>
                         </tr>
                         <tr>
                             <td class="text-align-right">상위 팀</td>
-                            <td>PMS25프로젝트</td>
+                            <td id="parent-team-name">-</td>
                             <td class="text-align-right">시스템/업무</td>
-                            <td>철도업무시스템</td>
+                            <td id="system-name">-</td>
                         </tr>
                         <tr>
                             <td colspan="4" class="text-align-center">팀 설명</td>
                         </tr>
                         <tr>
-                            <td colspan="4">
+                            <td colspan="4" id="team-description">
                                 -
                             </td>
                         </tr>
@@ -90,7 +109,7 @@
                             <button class="">참여시작</button>
                             <button class="">참여종료</button>
                             <button class="">해제</button>
-                            <button class="">인력등록</button>
+                            <button class="" onclick="openGroupPopup()">인력등록</button>
                         </div>
                     </div>
                     <div style="position: relative;height:270px;" id="grid-parent">
@@ -109,35 +128,35 @@
                     <table class="detail-table">
                         <tr>
                             <td class="text-align-right">성명</td>
-                            <td colspan="3">홍길동</td>
+                            <td colspan="3" id="member-name"></td>
                         </tr>
                         <tr>
                             <td class="text-align-right">프로젝트 권한</td>
-                            <td>팀원</td>
+                            <td id="project-auth"></td>
                             <td class="text-align-right"> 기술등급</td>
-                            <td>초급</td>
+                            <td id="tech-grade"></td>
                         </tr>
                         <tr>
                             <td class="text-align-right">직위</td>
-                            <td colspan="3">사원</td>
+                            <td colspan="3" id="position"></td>
                         </tr>
                         <tr>
                             <td class="text-align-right">예정참여시작일</td>
-                            <td></td>
+                            <td id="pre-start-date"></td>
                             <td class="text-align-right"> 예정참여종료일</td>
-                            <td></td>
+                            <td id="pre-end-date"></td>
                         </tr>
                         <tr>
                             <td class="text-align-right">참여시작일</td>
-                            <td></td>
+                            <td id="start-date"></td>
                             <td class="text-align-right">참여종료일</td>
-                            <td></td>
+                            <td id="end-date"></td>
                         </tr>
                         <tr>
                             <td class="text-align-right">Email</td>
-                            <td></td>
+                            <td id="email"></td>
                             <td class="text-align-right">내선전화</td>
-                            <td></td>
+                            <td id="phone-no"></td>
                         </tr>
                     </table>
 
@@ -145,26 +164,8 @@
                         <div class="team-title">소속팀 목록</div>
                     </div>
                     <table class="team-table">
-                        <tr>
-                            <td>팀명</td>
-                            <td>
-                                <select>
-                                    <option>팀A</option>
-                                    <option>팀B</option>
-                                </select>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>팀명</td>
-                            <td>
-                                <select>
-                                    <option>팀A</option>
-                                    <option>팀B</option>
-                                </select>
-                            </td>
-                        </tr>
-                    </table>
 
+                    </table>
                 </div>
             </div>
         </div>

--- a/src/main/webapp/resources/member/css/list.css
+++ b/src/main/webapp/resources/member/css/list.css
@@ -1,3 +1,15 @@
+#tree-table th, #tree-table td {
+    text-align: center;
+    vertical-align: middle;
+    padding: 10px;
+    font-size: 14px;
+}
+
+
+#tree-table td:nth-child(1){
+    text-align: left;
+}
+
 .member-content {
     display: flex;
     padding-top: 15px;
@@ -23,7 +35,7 @@
 .left-section {
     flex: 0.8;
     background-color: white;
-    border: 1px solid black;
+
     padding-bottom: 20px;
 }
 
@@ -55,6 +67,10 @@
 
 .team-overview, .team-members, .member-detail {
     margin-bottom: 30px;
+}
+
+.member-detail {
+    display: none;
 }
 
 .overview-table, .members-table, .detail-table {
@@ -120,7 +136,7 @@
 }
 
 .team-title {
-    font-size: 16px;
+    font-size: 20px;
     color: black;
     font-weight: bold;
 }
@@ -137,11 +153,15 @@
 
 .btn-group > button {
     padding: 4px 10px 4px 10px;
-    background-color: #717070;
+    background-color: #8B8B8B;
     color: white;
     border: none;
     border-radius: 5px;
     cursor: pointer;
+}
+
+#btnEdit {
+    margin-left: 85px;
 }
 
 .text-align-right {
@@ -167,4 +187,15 @@
 
 .detail-table > tbody > tr > td {
     width: 100px;
+}
+
+
+.clickable-name {
+    color: blue;
+    cursor: pointer;
+    text-decoration: underline;
+}
+
+.clickable-name:hover {
+    color: darkblue;
 }

--- a/src/main/webapp/resources/member/js/list.js
+++ b/src/main/webapp/resources/member/js/list.js
@@ -1,29 +1,36 @@
 var teamMemberGrid;
-
+var editMode = false;
+var projectNo = 1;
 $(document).ready(function() {
+    loadTeamData(projectNo);  // 처음 로드 시 team 데이터를 불러오는 함수 호출
+
+    $("#btnEdit").click(function () {
+        toggleEditMode();  // 편집 모드 토글 함수
+    });
+
     teamMemberGrid = new ax5.ui.grid();
     teamMemberGrid.setConfig({
         showRowSelector: true,
         target: $('[data-ax5grid="teamMemberGrid"]'),
         columns: [
-            {key: "name", label: "성명", align: "center"},
+            {key: "memberName", label: "성명", align: "center", formatter: function() {
+                    return '<a href="#" class="clickable-name member-link" data-id="' + this.item.id + '">' + this.value + '</a>';
+            }},
             {key: "auth", label: "프로젝트 권환", align: "center" },
-            {key: "group", width: 110, label: "소속", align: "center"},
+            {key: "groupName", width: 110, label: "소속", align: "center"},
             {key: "position", width: 80, label: "직위",align: "center"},
-            {key: "pre_st_dt", width: 120, label: "예정시작일",align: "center"},
-            {key: "pre_end_dt", width:120, label: "예정종료일", align: "center"},
-            {key: "st_dt", width: 120, label: "참여시작일", align: "center" },
-            {key: "end_dt", width: 120, label: "참여종료일", align: "center"},
-            {key: "techGrade", width: 80, label: "기술등급",align: "center"}
+            {key: "preStartDate", width: 120, label: "예정시작일",align: "center"},
+            {key: "preEndDate", width:120, label: "예정종료일", align: "center"},
+            {key: "startDate", width: 120, label: "참여시작일", align: "center" },
+            {key: "endDate", width: 120, label: "참여종료일", align: "center"},
+            {key: "tech", width: 80, label: "기술등급",align: "center"}
         ],
         page: {
             display: false
         }
     });
 
-    teamMemberGrid.setData([
-        {id: 101, name: "김연호", auth: "PM", group: "SI 1팀", position: "차장", pre_st_dt: "2024-05-12", pre_end_dt: "2025-05-12", techGrade: "고급"},
-    ]);
+
 });
 
 function openGroupPopup() {
@@ -33,3 +40,222 @@ function openGroupPopup() {
         "width=1000, height=800, resizable=yes"
     );
 }
+
+// 팀 데이터를 불러오는 함수
+function loadTeamData(projectNo) {
+    $.ajax({
+        url: 'http://localhost:8085/teams',
+        method: 'GET',
+        data: { projectNo: projectNo },
+        success: function (response) {
+            var treeData = response;
+            renderTeamTree(treeData);  // FancyTree 초기화 함수 호출
+        },
+        error: function (error) {
+            console.error("데이터를 가져오는 중 오류 발생:", error);
+        }
+    });
+}
+
+// 검색 기능 설정
+function setupSearch() {
+    var tree = $("#tree-table").fancytree("getTree");
+
+    // 검색, 필터 로직
+    $("input[name=search]").on("keyup", function(e) {
+        var match = $(this).val();
+
+        if(e && e.which === $.ui.keyCode.ESCAPE || $.trim(match) === ""){
+            $("button#btnResetSearch").trigger("click");
+            return;
+        }
+
+        var n = tree.filterNodes(match, {
+            autoExpand: true,
+            highlight: true,
+            mode: "dimm"
+        });
+
+        tree.visit(function(node) {
+            if (node.match || node.subMatch) {
+                node.setExpanded(true);
+            }
+        });
+
+        $("button#btnResetSearch").attr("disabled", false);
+        $("span#matches").text("(" + n + "개 찾음)");
+    });
+
+    // 검색, 필터 리셋 버튼
+    $("button#btnResetSearch").click(function(e) {
+        $("input[name=search]").val("");
+        $("span#matches").text("");
+        tree.clearFilter();
+        tree.visit(function(node) {
+            node.setExpanded(false);  // 모든 노드를 접음
+        });
+    }).attr("disabled", true);
+}
+
+// FancyTree 초기화 함수
+function renderTeamTree(treeData) {
+    $("#tree-table").fancytree({
+        extensions: ["table", "dnd5", "filter"],
+        checkbox: false,
+        selectMode: 1,
+        quicksearch: true,
+        source: treeData,
+        icon: false,
+        filter: {
+            autoApply: true,
+            autoExpand: true,
+            counter: true,
+            fuzzy: false,
+            hideExpandedCounter: true,
+            hideExpanders: false,
+            highlight: true,
+            leavesOnly: false,
+            nodata: true,
+            mode: "dimm"
+        },
+        table: {
+            indentation: 20,
+            nodeColumnIdx: 0,
+            checkboxColumnIdx: 0
+        },
+        renderColumns: function (event, data) {
+            var node = data.node,
+                $tdList = $(node.tr).find(">td");
+
+            $tdList.eq(0).text(node.data.title);
+            $tdList.eq(1).text(node.data.systemName || "-");
+            $tdList.eq(2).text(node.data.totalCount || "-");
+        },
+        dnd5: {
+            autoExpandMS: 400,
+            preventRecursion: false,
+            dragStart: function (node, data) {
+                return false;
+            },
+            dragEnter: function (node, data) {
+                return false;
+            },
+            dragDrop: function (node, data) {
+                data.otherNode.moveTo(node, data.hitMode);
+            }
+        },
+        activate: function(event, data) {
+            var node = data.node;
+            var teamKey = node.key;
+            var teamName = node.title;
+
+            updateTeamInfo(node.data, teamName);
+            loadTeamMembers(teamKey);
+        }
+    });
+
+    setupSearch();
+}
+
+// 편집 모드 토글 함수
+function toggleEditMode() {
+    editMode = !editMode;
+    if (editMode) {
+        $("#btnEdit").text("저장");
+        $(".fancytree-container").fancytree("option", "dnd5", {
+            autoExpandMS: 400,
+            preventRecursion: true,
+            dragStart: function (node, data) {
+                return true;
+            },
+            dragEnter: function (node, data) {
+                return true;
+            },
+            dragDrop: function (node, data) {
+                data.otherNode.moveTo(node, data.hitMode);
+            }
+        });
+    } else {
+        $("#btnEdit").text("순서 편집");
+        $(".fancytree-container").fancytree("option", "dnd5", null);
+        alert("순서가 저장되었습니다");
+    }
+}
+
+
+// 선택된 팀의 정보를 표시하는 함수
+function updateTeamInfo(teamData, teamName) {
+    console.log(teamData);
+    $("#team-name").text(teamName || "-");
+    $("#parent-team-name").text(teamData.parentTeamName || "-");
+    $("#system-name").text(teamData.systemName || "-");
+    $("#team-description").text(teamData.teamDescription || "-");
+
+    $(".header1").html('<span class="member-title">인력</span> ' + (teamData.totalCount || 0));
+}
+
+
+// 팀원 목록 불러오기
+function loadTeamMembers(teamKey) {
+    console.log("선택한 팀의 key: " + teamKey);
+
+    $.ajax({
+        url: 'http://localhost:8085/members',
+        method: 'GET',
+        data: {teamNo: teamKey},
+        dataType: 'json',
+        success: function(response) {
+            console.log("팀원 목록 데이터:", response);
+            teamMemberGrid.setData(response);
+        },
+        error: function(error) {
+            console.error("팀원 목록 불러오기 실패:", error);
+        }
+    });
+}
+
+
+$(document).on("click", ".member-link", function(e) {
+    e.preventDefault();
+    var memberId = $(this).data("id");
+
+    var memberData = teamMemberGrid.list.find(item => item.id === memberId);
+
+    if (memberData) {
+        updateMemberDetail(memberData);
+    }
+});
+
+function updateMemberDetail(memberData) {
+    // 성명, 프로젝트 권한, 직위, 기술등급, 이메일, 전화번호 정보 업데이트
+    $("#member-name").text(memberData.memberName || '-');
+    $("#project-auth").text(memberData.auth || '-');
+    $("#tech-grade").text(memberData.tech || '-');
+    $("#position").text(memberData.position || '-');
+    $("#pre-start-date").text(memberData.preStartDate || '-');
+    $("#pre-end-date").text(memberData.preEndDate || '-');
+    $("#start-date").text(memberData.startDate || '-');
+    $("#end-date").text(memberData.endDate || '-');
+    $("#email").text(memberData.email || '-');
+    $("#phone-no").text(memberData.phoneNo || '-');
+
+
+    const teamTable = $(".team-table");
+    teamTable.empty();
+
+    memberData.connectTeams.forEach(team => {
+        const row = `<tr>
+                        <td>팀명</td>
+                        <td>
+                            <select>
+                                <option>${team.teamName}</option>
+                            </select>
+                        </td>
+                    </tr>`;
+        teamTable.append(row);
+    });
+
+    $(".member-detail").show();
+}
+
+


### PR DESCRIPTION
# 작업 내용
- 프로젝트 팀 목록을 트리구조로 조회합니다.
- FancyTree 라이브러리를 사용합니다.
- 팀 클릭 시 상세 정보를 조회합니다.
- 팀 개요 및 팀에 소속된 사원들을 조회합니다.
- 사원명 클릭 시 사원상세 정보를 조회합니다.
- 겸직이 가능하기에 조회되는 팀의 수는 다를 수 있습니다.

# To Reviewers
팀 클릭 후 팀원 목록 조회 서버 로직은 Member 도메인에 있어야 할 것 같습니다
팀원 분들 리뷰 참고하겠습니다.

# Screen Shot (선택)
![image](https://github.com/user-attachments/assets/a95f98f5-063a-48b2-a766-c7977a2e0acf)
![image](https://github.com/user-attachments/assets/64d87bd9-6676-4af0-afc1-a3aae30d2fa0)

# Issue
- resolved: #45 
