### PR TITLE
[#55] 결함 관리 도메인 UI 및 로직 구현

### DIFF
--- a/src/main/java/com/kcc/pms/domain/task/defect/controller/DefectController.java
+++ b/src/main/java/com/kcc/pms/domain/task/defect/controller/DefectController.java
@@ -1,0 +1,24 @@
+package com.kcc.pms.domain.task.defect.controller;
+
+import lombok.NoArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@NoArgsConstructor
+@RequestMapping("/projects/{projectId}/defects")
+public class DefectController {
+
+    @GetMapping
+    public String findAll(){
+        return "defect/list";
+    }
+
+    @GetMapping("/{id}")
+    public String findById(Model model, @PathVariable Long id) {
+        return "defect/defect";
+    }
+}

--- a/src/main/java/com/kcc/pms/domain/test/controller/TestController.java
+++ b/src/main/java/com/kcc/pms/domain/test/controller/TestController.java
@@ -10,8 +10,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @RequestMapping("/projects/tests")
 public class TestController {
 
-    @GetMapping("/list")
-    public String list() {
+    @GetMapping
+    public String findAll() {
         return "test/list";
     }
 

--- a/src/main/webapp/WEB-INF/views/common.jsp
+++ b/src/main/webapp/WEB-INF/views/common.jsp
@@ -94,7 +94,7 @@
             <ul class="submenu">
                 <li><a href="/projects/dangers"><span class="dot">•</span>위험 관리</a></li>
                 <li><a href="/projects/issues"><span class="dot">•</span>이슈 관리</a></li>
-                <li><a href="#"><span class="dot">•</span>결함 관리</a></li>
+                <li><a href="/projects/defects/list"><span class="dot">•</span>결함 관리</a></li>
                 <li><a href="#"><span class="dot">•</span>요구사항 관리</a></li>
             </ul>
         </li>
@@ -105,7 +105,7 @@
                 <i class="fas fa-chevron-down toggle-arrow"></i>
             </a>
             <ul class="submenu">
-                <li><a href="#"><span class="dot">•</span>테스트 관리</a></li>
+                <li><a href="/projects/tests"><span class="dot">•</span>테스트 관리</a></li>
             </ul>
         </li>
 

--- a/src/main/webapp/WEB-INF/views/defect/defect.jsp
+++ b/src/main/webapp/WEB-INF/views/defect/defect.jsp
@@ -1,0 +1,166 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>KCC PMS</title>
+
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"></script>
+
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/dropzone/5.9.3/min/dropzone.min.js"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/dropzone/5.9.3/min/dropzone.min.css" />
+
+    <link rel="stylesheet" href="../../../resources/defect/css/defect.css">
+    <script src="../../../resources/defect/js/defect.js"></script>
+</head>
+<body>
+<!-- 샘플 데이터 -->
+<%@ page import="java.util.List" %>
+<%@ page import="java.util.ArrayList" %>
+<%@ page import="java.util.HashMap" %>
+<%@ page import="java.util.Map" %>
+
+<%
+    // 데이터 목록 준비
+    List<String> tasks = new ArrayList<>();
+    tasks.add("");
+    tasks.add("연결 작업 1");
+    tasks.add("연결 작업 2");
+    tasks.add("연결 작업 3");
+    // JSP 페이지의 Attribute로 데이터 목록을 설정
+    request.setAttribute("tasks", tasks);
+
+    Map<Integer, String> sys_type = new HashMap<>();
+    sys_type.put(0, "선택");
+    sys_type.put(1, "단위 테스트");
+    sys_type.put(2, "통합 테스트");
+    request.setAttribute("sys_type", sys_type);
+%>
+
+<c:set var="type" value="${type}" />
+<c:choose>
+    <c:when test="${type eq 'register'}">
+        <c:set var="titleName" value="결함 등록" />
+        <c:set var="disabled" value="" />
+    </c:when>
+    <c:when test="${type eq 'modify'}">
+        <c:set var="titleName" value="결함 수정" />
+        <c:set var="disabled" value="" />
+    </c:when>
+    <c:otherwise>
+        <c:set var="titleName" value="결함 상세" />
+        <c:set var="disabled" value="disabled" />
+    </c:otherwise>
+</c:choose>
+<input type="hidden" class="disabled-val" value="${disabled}" />
+
+    <section class="d-flex justify-content-between align-items-center">
+        <label class="ms-4 fw-bold fs-3 text-black">
+            ${titleName}</label>
+    </section>
+    <hr>
+    <section>
+        <table class="defect-table">
+            <tr>
+                <td class="td-title">결함 명</td>
+                <td class="font-nowrap">
+                    <input type="text" class="defect-name" value="요구사항정의서 ID미부여 항목 발견" required ${disabled} >
+                </td>
+                <td class="td-title">시스템 분류</td>
+                <td>
+                    <select name="sys-type" class="type" required ${disabled} >
+                        <c:forEach var="sys" items="${sys_type}">
+                            <option value="${sys.key}" ${sys.key == 0 ? 'selected' : ''}>${sys.value}</option>
+                        </c:forEach>
+                    </select>
+                </td>
+            </tr>
+            <tr>
+                <td class="td-title">결함 ID</td>
+                <td ${disabled}>
+                    <input type="text" class="defect-id" value="TT-123-asd-1-df_1" required ${disabled} >
+                </td>
+                <td class="td-title">테스트 ID</td>
+                <td ${disabled}>
+                    <input type="text" class="defect-id" value="TT-123-asd-1" required ${disabled} >
+                </td>
+            </tr>
+            <tr>
+                <td colspan="4" class="td-title">결함 설명</td>
+            </tr>
+            <tr>
+                <td colspan="4">
+                    <textarea id="defect_desc" class="defect-desc" required ${disabled} ></textarea>
+                </td>
+            </tr>
+            <tr>
+                <td class="td-title">우선순위</td>
+                <td>
+                    <select name="sys-type" class="type" required ${disabled} >
+                        <c:forEach var="sys" items="${sys_type}">
+                            <option value="${sys.key}" ${sys.key == 0 ? 'selected' : ''}>${sys.value}</option>
+                        </c:forEach>
+                    </select>
+                </td>
+                <td class="td-title">상태</td>
+                <td>
+                    <select name="sys-type" class="type" required ${disabled} >
+                        <c:forEach var="sys" items="${sys_type}">
+                            <option value="${sys.key}" ${sys.key == 0 ? 'selected' : ''}>${sys.value}</option>
+                        </c:forEach>
+                    </select>
+                </td>
+            </tr>
+            <tr>
+                <td class="td-title">발견자</td>
+                <td>
+                    <span>홍길동</span>
+                </td>
+            </tr>
+            <tr>
+                <td class="td-title">발견일자</td>
+                <td>
+                    <input type="date" class="date" name="date" value="" required ${disabled} >
+                </td>
+                <td class="td-title">조치희망일</td>
+                <td>
+                    <input type="date" class="date" name="date" value="" required ${disabled} >
+                </td>
+            </tr>
+            <tr>
+                <td class="td-title">조치일자</td>
+                <td>
+                    <input type="date" class="date" name="date" value="" required ${disabled} >
+                </td>
+            </tr>
+        </table>
+        <div class="file-zone_1 w-100">
+            <div class="file-section mt-3">
+                <div class="info-item d-flex flex-column align-items-start">
+                    <div class="mb-2"><label>결함 발견 첨부파일</label></div>
+                    <div id="df-insert-file-dropzone_1" class="dropzone"></div>
+                    <jsp:include page="../output/file/file.jsp" />
+                </div>
+            </div>
+        </div>
+        <div class="file-zone_2 w-100">
+            <div class="file-section mt-3">
+                <div class="info-item d-flex flex-column align-items-start">
+                    <div class="mb-2"><label>결함 발견 첨부파일</label></div>
+                    <div id="df-insert-file-dropzone_2" class="dropzone"></div>
+                    <jsp:include page="../output/file/file.jsp" />
+                </div>
+            </div>
+        </div>
+        <br><br><br>
+    </section>
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/views/defect/defect.jsp
+++ b/src/main/webapp/WEB-INF/views/defect/defect.jsp
@@ -50,6 +50,28 @@
     <c:when test="${type eq 'register'}">
         <c:set var="titleName" value="결함 등록" />
         <c:set var="disabled" value="" />
+        <c:set var="save" value="저장" />
+        <c:set var="cancel" value="취소" />
+    </c:when>
+    <c:when test="${type eq 'modify'}">
+        <c:set var="titleName" value="결함 수정" />
+        <c:set var="disabled" value="" />
+        <c:set var="save" value="저장" />
+        <c:set var="cancel" value="취소" />
+    </c:when>
+    <c:otherwise>
+        <c:set var="titleName" value="결함 상세" />
+        <c:set var="disabled" value="disabled" />
+        <c:set var="work" value="조치" />
+        <c:set var="modify" value="수정" />
+    </c:otherwise>
+</c:choose>
+
+<c:set var="type" value="${type}" />
+<c:choose>
+    <c:when test="${type eq 'register'}">
+        <c:set var="titleName" value="결함 등록" />
+        <c:set var="disabled" value="" />
     </c:when>
     <c:when test="${type eq 'modify'}">
         <c:set var="titleName" value="결함 수정" />
@@ -98,7 +120,7 @@
             </tr>
             <tr>
                 <td colspan="4">
-                    <textarea id="defect_desc" class="defect-desc" required ${disabled} ></textarea>
+                    <textarea class="defect-desc" required ${disabled} ></textarea>
                 </td>
             </tr>
             <tr>
@@ -151,15 +173,42 @@
                 </div>
             </div>
         </div>
-        <div class="file-zone_2 w-100">
-            <div class="file-section mt-3">
-                <div class="info-item d-flex flex-column align-items-start">
-                    <div class="mb-2"><label>결함 발견 첨부파일</label></div>
-                    <div id="df-insert-file-dropzone_2" class="dropzone"></div>
-                    <jsp:include page="../output/file/file.jsp" />
+        <br>
+        <c:if test="${not empty defectActionContent and defectActionContent != ''}">
+            <section class="defect-table work-info w-100">
+                <table>
+                    <tr>
+                        <td colspan="4" class="td-title text-center">결함 조치 내용</td>
+                    </tr>
+                    <tr>
+                        <td colspan="4">
+                            <textarea class="defect-desc" required ${disabled} >${defectActionContent}</textarea>
+                        </td>
+                    </tr>
+                </table>
+                <div class="file-zone_2 w-100">
+                    <div class="file-section mt-3">
+                        <div class="info-item d-flex flex-column align-items-start">
+                            <div class="mb-2"><label>결함 발견 첨부파일</label></div>
+                            <div id="df-insert-file-dropzone_2" class="dropzone"></div>
+                            <jsp:include page="../output/file/file.jsp" />
+                        </div>
+                    </div>
                 </div>
-            </div>
-        </div>
+            </section>
+        </c:if>
+        <section class="btn-sec d-flex justify-content-end">
+            <c:choose>
+                <c:when test="${type eq 'register' or type eq 'modify'}">
+                    <button class="btn btn-success" id="save">&nbsp;&nbsp;&nbsp;${save}&nbsp;&nbsp;&nbsp;</button>&nbsp;&nbsp;&nbsp;
+                    <button class="btn btn-secondary me-3" id="cancel">&nbsp;&nbsp;&nbsp;${cancel}&nbsp;&nbsp;&nbsp;</button>
+                </c:when>
+                <c:otherwise>
+                    <button class="btn btn-primary" id="work">&nbsp&nbsp;&nbsp;${work}&nbsp;&nbsp;&nbsp;</button>&nbsp;&nbsp;&nbsp;
+                    <button class="btn btn-secondary me-3" id="modify">&nbsp;&nbsp;&nbsp;${modify}&nbsp;&nbsp;&nbsp;</button>
+                </c:otherwise>
+            </c:choose>
+        </section>
         <br><br><br>
     </section>
 </body>

--- a/src/main/webapp/WEB-INF/views/defect/list.jsp
+++ b/src/main/webapp/WEB-INF/views/defect/list.jsp
@@ -1,0 +1,87 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+
+<%@ include file="../common.jsp" %>
+<%--<link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/ax5ui/ax5ui-grid/master/dist/ax5grid.css">--%>
+<link rel="stylesheet" type="text/css" href="../../../resources/test/css/ax5grid.css">
+<link rel="stylesheet" type="text/css" href="../../../resources/test/css/list.css">
+
+<!-- 샘플 데이터 -->
+<%@ page import="java.util.List" %>
+<%@ page import="java.util.ArrayList" %>
+
+<%
+    // 데이터 목록 준비
+    List<String> tasks = new ArrayList<>();
+    tasks.add("연결 작업 1");
+    tasks.add("연결 작업 2");
+    tasks.add("연결 작업 3");
+    // JSP 페이지의 Attribute로 데이터 목록을 설정
+    request.setAttribute("tasks", tasks);
+%>
+
+<main class="content" id="content">
+    <div class="main_content">
+        <br>
+        <div class="ps-5 pe-5">
+            <section>
+                <div class="d-flex justify-content-between align-items-center">
+                    <label class="ms-4 fw-bold fs-2 text-black">
+                        결함 관리</label>
+                    <div class="d-flex justify-content-center">
+                        <button type="button" class="btn btn-primary d-flex justify-content-end align-items-center me-4 text-nowrap">
+                            <i class="fas fa-plus"></i>&nbsp;&nbsp;테스트 등록</button>
+                        <input type="text" class="form-control" id="searchTest" placeholder="테스트를 검색하세요." style="height: 40px;">
+                        &nbsp;&nbsp;
+                        <button id="test-search-btn" class="custom-button d-flex align-items-center me-3 text-nowrap">&nbsp;&nbsp;&nbsp;&nbsp;검색&nbsp;&nbsp;&nbsp;&nbsp;</button>
+                    </div>
+                </div>
+            </section>
+            <hr>
+            <section>
+                <div class="d-flex justify-content-end align-items-center me-5">
+                    <div class="me-4">
+                        <label>시스템 분류</label>&nbsp;&nbsp;&nbsp;
+                        <label>
+                            <select name="taskSelect" class="form-select">
+                                <c:forEach var="task" items="${tasks}">
+                                    <option value="${task}">${task}</option>
+                                </c:forEach>
+                            </select>
+                        </label>
+                    </div>
+                    <div class="me-4">
+                        <label>결함 분류</label>&nbsp;&nbsp;&nbsp;
+                        <label>
+                            <select name="taskSelect" class="form-select">
+                                <c:forEach var="task" items="${tasks}">
+                                    <option value="${task}">${task}</option>
+                                </c:forEach>
+                            </select>
+                        </label>
+                    </div>
+                </div>
+            </section>
+            <section>
+                <div class="d-flex justify-content-center">
+                    <div style="width: 91.5%;">
+                        <div style="position: relative;height:100%;" id="test-grid-parent">
+                            <div class="list_table" data-ax5grid="first-grid"  data-ax5grid-config="{
+                            header: {
+                                columnHeight: 50,
+                            },
+                            body: {
+                                columnHeight: 50
+                            }
+                        }" style="height: 575px;">
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+        </div>
+    </div>
+
+    <script src="../../../resources/defect/js/list.js"></script>
+</main>
+
+<%@ include file="../footer.jsp" %>

--- a/src/main/webapp/WEB-INF/views/defect/list.jsp
+++ b/src/main/webapp/WEB-INF/views/defect/list.jsp
@@ -29,8 +29,8 @@
                         결함 관리</label>
                     <div class="d-flex justify-content-center">
                         <button type="button" class="btn btn-primary d-flex justify-content-end align-items-center me-4 text-nowrap">
-                            <i class="fas fa-plus"></i>&nbsp;&nbsp;테스트 등록</button>
-                        <input type="text" class="form-control" id="searchTest" placeholder="테스트를 검색하세요." style="height: 40px;">
+                            <i class="fas fa-plus"></i>&nbsp;&nbsp;결함 등록</button>
+                        <input type="text" class="form-control" id="searchTest" placeholder="결함 검색하세요." style="height: 40px;">
                         &nbsp;&nbsp;
                         <button id="test-search-btn" class="custom-button d-flex align-items-center me-3 text-nowrap">&nbsp;&nbsp;&nbsp;&nbsp;검색&nbsp;&nbsp;&nbsp;&nbsp;</button>
                     </div>
@@ -77,6 +77,8 @@
                         </div>
                     </div>
                 </div>
+            </section>
+            <section class="button-list">
             </section>
         </div>
     </div>

--- a/src/main/webapp/WEB-INF/views/output/modal/file-insert-modal.jsp
+++ b/src/main/webapp/WEB-INF/views/output/modal/file-insert-modal.jsp
@@ -42,16 +42,16 @@
         overflow-y: hidden;
     }
 
+    .jstree-div {
+        border: 1px solid #ced4da;
+    }
+
     .file-zone .select-box {
         margin-left: 20px;
         width: 250px;
         height: 150px;
         padding: 10px;
         overflow-y: auto;
-    }
-
-    .jstree-div {
-        border: 1px solid #ced4da;
     }
 
     .file-zone .dropzone {

--- a/src/main/webapp/WEB-INF/views/test/test.jsp
+++ b/src/main/webapp/WEB-INF/views/test/test.jsp
@@ -43,7 +43,7 @@
         <c:set var="disabled" value="disabled" />
     </c:otherwise>
 </c:choose>
-<input type="hidden" id="disabled-val" value="${disabled}" />
+<input type="hidden"  class="disabled-val" value="${disabled}" />
 
 <main class="content" id="content">
     <div class="main_content">

--- a/src/main/webapp/resources/defect/css/ax5grid.css
+++ b/src/main/webapp/resources/defect/css/ax5grid.css
@@ -1,0 +1,1591 @@
+/*!
+ * Copyright (c) 2017. tom@axisj.com
+ * - github.com/thomasjang
+ * - www.axisj.com
+ */
+/*!
+ * Copyright (c) 2017. tom@axisj.com
+ * - github.com/thomasjang
+ * - www.axisj.com
+ */
+fieldset {
+    padding: 0;
+    margin: 0;
+    border: 0;
+    min-width: 0
+}
+
+legend {
+    display: block;
+    width: 100%;
+    padding: 0;
+    margin-bottom: 20px;
+    font-size: 21px;
+    line-height: inherit;
+    color: #333;
+    border: 0;
+    border-bottom: 1px solid #e5e5e5
+}
+
+label {
+    display: inline-block;
+    max-width: 100%;
+    margin-bottom: 5px;
+}
+
+input[type="search"] {
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box
+}
+
+input[type="radio"],input[type="checkbox"] {
+    margin: 4px 0 0;
+    margin-top: 1px \9;
+    line-height: normal
+}
+
+input[type="file"] {
+    display: block
+}
+
+input[type="range"] {
+    display: block;
+    width: 100%
+}
+
+select[multiple],select[size] {
+    height: auto
+}
+
+input[type="file"]:focus,input[type="radio"]:focus,input[type="checkbox"]:focus {
+    outline: 5px auto -webkit-focus-ring-color;
+    outline-offset: -2px
+}
+
+output {
+    display: block;
+    padding-top: 7px;
+    font-size: 14px;
+    line-height: 1.42857;
+    color: #555
+}
+
+.form-control {
+    box-sizing: border-box;
+    display: block;
+    width: 100%;
+    height: 34px;
+    padding: 6px 12px;
+    font-size: 14px;
+    line-height: 1.42857;
+    color: #555;
+    background-color: #fff;
+    background-image: none;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,0.075);
+    box-shadow: inset 0 1px 1px rgba(0,0,0,0.075);
+    -webkit-transition: border-color ease-in-out 0.15s,box-shadow ease-in-out 0.15s;
+    -o-transition: border-color ease-in-out 0.15s,box-shadow ease-in-out 0.15s;
+    transition: border-color ease-in-out 0.15s,box-shadow ease-in-out 0.15s
+}
+
+.form-control:focus {
+    border-color: #66afe9;
+    outline: 0;
+    -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,0.075),0 0 8px rgba(102,175,233,0.6);
+    box-shadow: inset 0 1px 1px rgba(0,0,0,0.075),0 0 8px rgba(102,175,233,0.6)
+}
+
+.form-control::-moz-placeholder {
+    color: #999;
+    opacity: 1
+}
+
+.form-control:-ms-input-placeholder {
+    color: #999
+}
+
+.form-control::-webkit-input-placeholder {
+    color: #999
+}
+
+.form-control::-ms-expand {
+    border: 0;
+    background-color: transparent
+}
+
+.form-control[disabled],.form-control[readonly],fieldset[disabled] .form-control {
+    background-color: #eee;
+    opacity: 1
+}
+
+.form-control[disabled],fieldset[disabled] .form-control {
+    cursor: not-allowed
+}
+
+textarea.form-control {
+    height: auto
+}
+
+input[type="search"] {
+    -webkit-appearance: none
+}
+
+@media screen and (-webkit-min-device-pixel-ratio: 0) {
+    input[type="date"].form-control,input[type="time"].form-control,input[type="datetime-local"].form-control,input[type="month"].form-control {
+        line-height:34px
+    }
+
+    input[type="date"].input-sm,.input-group-sm>input[type="date"].form-control,.input-group-sm>input[type="date"].input-group-addon,.input-group-sm>.input-group-btn>input[type="date"].btn,.input-group-sm input[type="date"],input[type="time"].input-sm,.input-group-sm>input[type="time"].form-control,.input-group-sm>input[type="time"].input-group-addon,.input-group-sm>.input-group-btn>input[type="time"].btn,.input-group-sm input[type="time"],input[type="datetime-local"].input-sm,.input-group-sm>input[type="datetime-local"].form-control,.input-group-sm>input[type="datetime-local"].input-group-addon,.input-group-sm>.input-group-btn>input[type="datetime-local"].btn,.input-group-sm input[type="datetime-local"],input[type="month"].input-sm,.input-group-sm>input[type="month"].form-control,.input-group-sm>input[type="month"].input-group-addon,.input-group-sm>.input-group-btn>input[type="month"].btn,.input-group-sm input[type="month"] {
+        line-height: 30px
+    }
+
+    input[type="date"].input-lg,.input-group-lg>input[type="date"].form-control,.input-group-lg>input[type="date"].input-group-addon,.input-group-lg>.input-group-btn>input[type="date"].btn,.input-group-lg input[type="date"],input[type="time"].input-lg,.input-group-lg>input[type="time"].form-control,.input-group-lg>input[type="time"].input-group-addon,.input-group-lg>.input-group-btn>input[type="time"].btn,.input-group-lg input[type="time"],input[type="datetime-local"].input-lg,.input-group-lg>input[type="datetime-local"].form-control,.input-group-lg>input[type="datetime-local"].input-group-addon,.input-group-lg>.input-group-btn>input[type="datetime-local"].btn,.input-group-lg input[type="datetime-local"],input[type="month"].input-lg,.input-group-lg>input[type="month"].form-control,.input-group-lg>input[type="month"].input-group-addon,.input-group-lg>.input-group-btn>input[type="month"].btn,.input-group-lg input[type="month"] {
+        line-height: 46px
+    }
+}
+
+.form-group {
+    margin-bottom: 15px
+}
+
+.radio,.checkbox {
+    position: relative;
+    display: block;
+    margin-top: 10px;
+    margin-bottom: 10px
+}
+
+.radio label,.checkbox label {
+    min-height: 20px;
+    padding-left: 20px;
+    margin-bottom: 0;
+    font-weight: normal;
+    cursor: pointer
+}
+
+.radio input[type="radio"],.radio-inline input[type="radio"],.checkbox input[type="checkbox"],.checkbox-inline input[type="checkbox"] {
+    position: absolute;
+    margin-left: -20px;
+    margin-top: 4px \9
+}
+
+.radio+.radio,.checkbox+.checkbox {
+    margin-top: -5px
+}
+
+.radio-inline,.checkbox-inline {
+    position: relative;
+    display: inline-block;
+    padding-left: 20px;
+    margin-bottom: 0;
+    vertical-align: middle;
+    font-weight: normal;
+    cursor: pointer
+}
+
+.radio-inline+.radio-inline,.checkbox-inline+.checkbox-inline {
+    margin-top: 0;
+    margin-left: 10px
+}
+
+input[type="radio"][disabled],input[type="radio"].disabled,fieldset[disabled] input[type="radio"],input[type="checkbox"][disabled],input[type="checkbox"].disabled,fieldset[disabled] input[type="checkbox"] {
+    cursor: not-allowed
+}
+
+.radio-inline.disabled,fieldset[disabled] .radio-inline,.checkbox-inline.disabled,fieldset[disabled] .checkbox-inline {
+    cursor: not-allowed
+}
+
+.radio.disabled label,fieldset[disabled] .radio label,.checkbox.disabled label,fieldset[disabled] .checkbox label {
+    cursor: not-allowed
+}
+
+.form-control-static {
+    padding-top: 7px;
+    padding-bottom: 7px;
+    margin-bottom: 0;
+    min-height: 34px
+}
+
+.form-control-static.input-lg,.input-group-lg>.form-control-static.form-control,.input-group-lg>.form-control-static.input-group-addon,.input-group-lg>.input-group-btn>.form-control-static.btn,.form-control-static.input-sm,.input-group-sm>.form-control-static.form-control,.input-group-sm>.form-control-static.input-group-addon,.input-group-sm>.input-group-btn>.form-control-static.btn {
+    padding-left: 0;
+    padding-right: 0
+}
+
+.input-sm,.input-group-sm>.form-control,.input-group-sm>.input-group-addon,.input-group-sm>.input-group-btn>.btn {
+    height: 30px;
+    padding: 5px 10px;
+    font-size: 12px;
+    line-height: 1.5;
+    border-radius: 3px
+}
+
+select.input-sm,.input-group-sm>select.form-control,.input-group-sm>select.input-group-addon,.input-group-sm>.input-group-btn>select.btn {
+    height: 30px;
+    line-height: 30px
+}
+
+textarea.input-sm,.input-group-sm>textarea.form-control,.input-group-sm>textarea.input-group-addon,.input-group-sm>.input-group-btn>textarea.btn,select[multiple].input-sm,.input-group-sm>select[multiple].form-control,.input-group-sm>select[multiple].input-group-addon,.input-group-sm>.input-group-btn>select[multiple].btn {
+    height: auto
+}
+
+.form-group-sm .form-control {
+    height: 30px;
+    padding: 5px 10px;
+    font-size: 12px;
+    line-height: 1.5;
+    border-radius: 3px
+}
+
+.form-group-sm select.form-control {
+    height: 30px;
+    line-height: 30px
+}
+
+.form-group-sm textarea.form-control,.form-group-sm select[multiple].form-control {
+    height: auto
+}
+
+.form-group-sm .form-control-static {
+    height: 30px;
+    min-height: 32px;
+    padding: 6px 10px;
+    font-size: 12px;
+    line-height: 1.5
+}
+
+.input-lg,.input-group-lg>.form-control,.input-group-lg>.input-group-addon,.input-group-lg>.input-group-btn>.btn {
+    height: 46px;
+    padding: 10px 16px;
+    font-size: 18px;
+    line-height: 1.33333;
+    border-radius: 6px
+}
+
+select.input-lg,.input-group-lg>select.form-control,.input-group-lg>select.input-group-addon,.input-group-lg>.input-group-btn>select.btn {
+    height: 46px;
+    line-height: 46px
+}
+
+textarea.input-lg,.input-group-lg>textarea.form-control,.input-group-lg>textarea.input-group-addon,.input-group-lg>.input-group-btn>textarea.btn,select[multiple].input-lg,.input-group-lg>select[multiple].form-control,.input-group-lg>select[multiple].input-group-addon,.input-group-lg>.input-group-btn>select[multiple].btn {
+    height: auto
+}
+
+.form-group-lg .form-control {
+    height: 46px;
+    padding: 10px 16px;
+    font-size: 18px;
+    line-height: 1.33333;
+    border-radius: 6px
+}
+
+.form-group-lg select.form-control {
+    height: 46px;
+    line-height: 46px
+}
+
+.form-group-lg textarea.form-control,.form-group-lg select[multiple].form-control {
+    height: auto
+}
+
+.form-group-lg .form-control-static {
+    height: 46px;
+    min-height: 38px;
+    padding: 11px 16px;
+    font-size: 18px;
+    line-height: 1.33333
+}
+
+.has-feedback {
+    position: relative
+}
+
+.has-feedback .form-control {
+    padding-right: 42.5px
+}
+
+.form-control-feedback {
+    position: absolute;
+    top: 0;
+    right: 0;
+    z-index: 2;
+    display: block;
+    width: 34px;
+    height: 34px;
+    line-height: 34px;
+    text-align: center;
+    pointer-events: none
+}
+
+.input-lg+.form-control-feedback,.input-group-lg>.form-control+.form-control-feedback,.input-group-lg>.input-group-addon+.form-control-feedback,.input-group-lg>.input-group-btn>.btn+.form-control-feedback,.input-group-lg+.form-control-feedback,.form-group-lg .form-control+.form-control-feedback {
+    width: 46px;
+    height: 46px;
+    line-height: 46px
+}
+
+.input-sm+.form-control-feedback,.input-group-sm>.form-control+.form-control-feedback,.input-group-sm>.input-group-addon+.form-control-feedback,.input-group-sm>.input-group-btn>.btn+.form-control-feedback,.input-group-sm+.form-control-feedback,.form-group-sm .form-control+.form-control-feedback {
+    width: 30px;
+    height: 30px;
+    line-height: 30px
+}
+
+.has-success .help-block,.has-success .control-label,.has-success .radio,.has-success .checkbox,.has-success .radio-inline,.has-success .checkbox-inline,.has-success.radio label,.has-success.checkbox label,.has-success.radio-inline label,.has-success.checkbox-inline label {
+    color: #3c763d
+}
+
+.has-success .form-control {
+    border-color: #3c763d;
+    -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,0.075);
+    box-shadow: inset 0 1px 1px rgba(0,0,0,0.075)
+}
+
+.has-success .form-control:focus {
+    border-color: #2b542c;
+    -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #67b168;
+    box-shadow: inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #67b168
+}
+
+.has-success .input-group-addon {
+    color: #3c763d;
+    border-color: #3c763d;
+    background-color: #dff0d8
+}
+
+.has-success .form-control-feedback {
+    color: #3c763d
+}
+
+.has-warning .help-block,.has-warning .control-label,.has-warning .radio,.has-warning .checkbox,.has-warning .radio-inline,.has-warning .checkbox-inline,.has-warning.radio label,.has-warning.checkbox label,.has-warning.radio-inline label,.has-warning.checkbox-inline label {
+    color: #8a6d3b
+}
+
+.has-warning .form-control {
+    border-color: #8a6d3b;
+    -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,0.075);
+    box-shadow: inset 0 1px 1px rgba(0,0,0,0.075)
+}
+
+.has-warning .form-control:focus {
+    border-color: #66512c;
+    -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #c0a16b;
+    box-shadow: inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #c0a16b
+}
+
+.has-warning .input-group-addon {
+    color: #8a6d3b;
+    border-color: #8a6d3b;
+    background-color: #fcf8e3
+}
+
+.has-warning .form-control-feedback {
+    color: #8a6d3b
+}
+
+.has-error .help-block,.has-error .control-label,.has-error .radio,.has-error .checkbox,.has-error .radio-inline,.has-error .checkbox-inline,.has-error.radio label,.has-error.checkbox label,.has-error.radio-inline label,.has-error.checkbox-inline label {
+    color: #a94442
+}
+
+.has-error .form-control {
+    border-color: #a94442;
+    -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,0.075);
+    box-shadow: inset 0 1px 1px rgba(0,0,0,0.075)
+}
+
+.has-error .form-control:focus {
+    border-color: #843534;
+    -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #ce8483;
+    box-shadow: inset 0 1px 1px rgba(0,0,0,0.075),0 0 6px #ce8483
+}
+
+.has-error .input-group-addon {
+    color: #a94442;
+    border-color: #a94442;
+    background-color: #f2dede
+}
+
+.has-error .form-control-feedback {
+    color: #a94442
+}
+
+.has-feedback label ~ .form-control-feedback {
+    top: 25px
+}
+
+.has-feedback label.sr-only ~ .form-control-feedback {
+    top: 0
+}
+
+.help-block {
+    display: block;
+    margin-top: 5px;
+    margin-bottom: 10px;
+    color: #737373
+}
+
+@media (min-width: 768px) {
+    .form-inline .form-group {
+        display:inline-block;
+        margin-bottom: 0;
+        vertical-align: middle
+    }
+
+    .form-inline .form-control {
+        display: inline-block;
+        width: auto;
+        vertical-align: middle
+    }
+
+    .form-inline .form-control-static {
+        display: inline-block
+    }
+
+    .form-inline .input-group {
+        display: inline-table;
+        vertical-align: middle
+    }
+
+    .form-inline .input-group .input-group-addon,.form-inline .input-group .input-group-btn,.form-inline .input-group .form-control {
+        width: auto
+    }
+
+    .form-inline .input-group>.form-control {
+        width: 100%
+    }
+
+    .form-inline .control-label {
+        margin-bottom: 0;
+        vertical-align: middle
+    }
+
+    .form-inline .radio,.form-inline .checkbox {
+        display: inline-block;
+        margin-top: 0;
+        margin-bottom: 0;
+        vertical-align: middle
+    }
+
+    .form-inline .radio label,.form-inline .checkbox label {
+        padding-left: 0
+    }
+
+    .form-inline .radio input[type="radio"],.form-inline .checkbox input[type="checkbox"] {
+        position: relative;
+        margin-left: 0
+    }
+
+    .form-inline .has-feedback .form-control-feedback {
+        top: 0
+    }
+}
+
+.form-horizontal .radio,.form-horizontal .checkbox,.form-horizontal .radio-inline,.form-horizontal .checkbox-inline {
+    margin-top: 0;
+    margin-bottom: 0;
+    padding-top: 7px
+}
+
+.form-horizontal .radio,.form-horizontal .checkbox {
+    min-height: 27px
+}
+
+.form-horizontal .form-group {
+    margin-left: -15px;
+    margin-right: -15px
+}
+
+.form-horizontal .form-group:before,.form-horizontal .form-group:after {
+    content: " ";
+    display: table
+}
+
+.form-horizontal .form-group:after {
+    clear: both
+}
+
+@media (min-width: 768px) {
+    .form-horizontal .control-label {
+        text-align:right;
+        margin-bottom: 0;
+        padding-top: 7px
+    }
+}
+
+.form-horizontal .has-feedback .form-control-feedback {
+    right: 15px
+}
+
+@media (min-width: 768px) {
+    .form-horizontal .form-group-lg .control-label {
+        padding-top:11px;
+        font-size: 18px
+    }
+}
+
+@media (min-width: 768px) {
+    .form-horizontal .form-group-sm .control-label {
+        padding-top:6px;
+        font-size: 12px
+    }
+}
+
+.input-group {
+    position: relative;
+    display: table;
+    border-collapse: separate
+}
+
+.input-group[class*="col-"] {
+    float: none;
+    padding-left: 0;
+    padding-right: 0
+}
+
+.input-group .form-control {
+    position: relative;
+    z-index: 2;
+    float: left;
+    width: 100%;
+    margin-bottom: 0
+}
+
+.input-group .form-control:focus {
+    z-index: 3
+}
+
+.input-group-addon,.input-group-btn,.input-group .form-control {
+    display: table-cell
+}
+
+.input-group-addon:not(:first-child):not(:last-child),.input-group-btn:not(:first-child):not(:last-child),.input-group .form-control:not(:first-child):not(:last-child) {
+    border-radius: 0
+}
+
+.input-group-addon,.input-group-btn {
+    width: 1%;
+    white-space: nowrap;
+    vertical-align: middle
+}
+
+.input-group-addon {
+    padding: 6px 12px;
+    font-size: 14px;
+    font-weight: normal;
+    line-height: 1;
+    color: #555;
+    text-align: center;
+    background-color: #eee;
+    border: 1px solid #ccc;
+    border-radius: 4px
+}
+
+.input-group-addon.input-sm,.input-group-sm>.input-group-addon,.input-group-sm>.input-group-btn>.input-group-addon.btn {
+    padding: 5px 10px;
+    font-size: 12px;
+    border-radius: 3px
+}
+
+.input-group-addon.input-lg,.input-group-lg>.input-group-addon,.input-group-lg>.input-group-btn>.input-group-addon.btn {
+    padding: 10px 16px;
+    font-size: 18px;
+    border-radius: 6px
+}
+
+.input-group-addon input[type="radio"],.input-group-addon input[type="checkbox"] {
+    margin-top: 0
+}
+
+.input-group .form-control:first-child,.input-group-addon:first-child,.input-group-btn:first-child>.btn,.input-group-btn:first-child>.btn-group>.btn,.input-group-btn:first-child>.dropdown-toggle,.input-group-btn:last-child>.btn:not(:last-child):not(.dropdown-toggle),.input-group-btn:last-child>.btn-group:not(:last-child)>.btn {
+    border-bottom-right-radius: 0;
+    border-top-right-radius: 0
+}
+
+.input-group-addon:first-child {
+    border-right: 0
+}
+
+.input-group .form-control:last-child,.input-group-addon:last-child,.input-group-btn:last-child>.btn,.input-group-btn:last-child>.btn-group>.btn,.input-group-btn:last-child>.dropdown-toggle,.input-group-btn:first-child>.btn:not(:first-child),.input-group-btn:first-child>.btn-group:not(:first-child)>.btn {
+    border-bottom-left-radius: 0;
+    border-top-left-radius: 0
+}
+
+.input-group-addon:last-child {
+    border-left: 0
+}
+
+.input-group-btn {
+    position: relative;
+    font-size: 0;
+    white-space: nowrap
+}
+
+.input-group-btn>.btn {
+    position: relative
+}
+
+.input-group-btn>.btn+.btn {
+    margin-left: -1px
+}
+
+.input-group-btn>.btn:hover,.input-group-btn>.btn:focus,.input-group-btn>.btn:active {
+    z-index: 2
+}
+
+.input-group-btn:first-child>.btn,.input-group-btn:first-child>.btn-group {
+    margin-right: -1px
+}
+
+.input-group-btn:last-child>.btn,.input-group-btn:last-child>.btn-group {
+    z-index: 2;
+    margin-left: -1px
+}
+
+[data-ax5grid] {
+    box-sizing: border-box
+}
+
+[data-ax5grid] *,[data-ax5grid] *:before,[data-ax5grid] *:after {
+    box-sizing: border-box
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] {
+    margin: 0;
+    padding: 0;
+    position: relative;
+    background: #fff;
+    /*border: 1px solid #ccc;*/
+    overflow: hidden
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="hidden"] {
+    margin: 0;
+    padding: 0;
+    position: absolute;
+    left: -100%;
+    top: -100%;
+    height: 100%;
+    width: 100%
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] {
+    user-select: none;
+    margin: 0;
+    padding: 0;
+    position: relative;
+    overflow: hidden;
+    background-color: #EBEEF3;
+    border-bottom: 1px solid #ccc;
+    color: #222
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel] {
+    margin: 0;
+    padding: 0;
+    position: absolute;
+    overflow: hidden
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel] table {
+    table-layout: fixed;
+    border-collapse: separate;
+    border-spacing: 0;
+    border: 0 none;
+    width: 90%;
+    height: 50%
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel] table tr {
+    border-bottom: 0 none
+}
+
+
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel] table tr[data-ax5grid-grouping-tr="true"] {
+    background: #ffffe7
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel] table tr[data-ax5grid-selected="true"] {
+    background: #e3f1ff
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel] table tr[data-ax5grid-selected="true"] td[data-ax5grid-column-attr="rowSelector"],[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel] table tr[data-ax5grid-selected="true"] td[data-ax5grid-column-attr="lineNumber"] {
+    box-shadow: none
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel] table tr[data-ax5grid-selected="true"] td[data-ax5grid-column-attr="rowSelector"] .checkBox:after {
+    opacity: 1
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel] table tr[data-ax5grid-disable-selection="true"] td[data-ax5grid-column-attr="rowSelector"] .checkBox {
+    cursor: not-allowed;
+    background-color: #d7d7d7;
+    background-image: -webkit-linear-gradient(top, #d7d7d7,#e6e6e6);
+    background-image: linear-gradient(to bottom,#d7d7d7,#e6e6e6)
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel] table tr[data-ax5grid-disable-selection="true"] td[data-ax5grid-column-attr="rowSelector"] .checkBox:after {
+    opacity: 0
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel] table tr td.merged {
+    background: #EDF0F5
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel] table tr td {
+    box-sizing: border-box;
+    overflow: hidden;
+    position: relative;
+    padding: 0;
+    font-size: 12px;
+    border: 0 none;
+    cursor: pointer;
+    box-shadow: inset 1px 1px 0px 0px #EDF0F5;
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel] table tr td.hasBorder {
+    /*border-right: 1px solid #ccc;*/
+    border-bottom: 1px solid #ccc
+}
+
+/*[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel] table tr td.focused {*/
+/*    box-shadow: inset 0px 0px 1px 1px #0581f2*/
+/*}*/
+
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel] table tr td[data-ax5grid-column-row="null"] {
+    box-shadow: none
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel] table tr td[data-ax5grid-column-row="null"] {
+    border-right: 0 none
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel] table tr td[data-ax5grid-column-selected] {
+    background: #b1d7fe;
+    border-color: #ccc;
+    color: #000
+}
+
+/*[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel] table tr td[data-ax5grid-column-focused] {*/
+/*    box-shadow: inset 0px 0px 1px 1px #0581f2;*/
+/*    background: #e3f1ff;*/
+/*    color: #000*/
+/*}*/
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel] table tr td[data-ax5grid-column-attr="rowSelector"] {
+    cursor: pointer
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel] table tr td[data-ax5grid-column-attr="rowSelector"] .checkBox {
+    display: block;
+    position: relative;
+    border: 1px solid #ccc;
+    border-radius: 3px;
+    background-color: #fff;
+    background-image: -webkit-linear-gradient(top, #fff,#F0F0F0);
+    background-image: linear-gradient(to bottom,#fff,#F0F0F0);
+    height: 100%;
+    width: 100%
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel] table tr td[data-ax5grid-column-attr="rowSelector"] .checkBox:after {
+    content: '';
+    width: 60%;
+    height: 40%;
+    position: absolute;
+    top: 20%;
+    right: 20%;
+    border: 0.2em solid #3372ff;
+    border-top: none;
+    border-right: none;
+    background: transparent;
+    opacity: 0.0;
+    -webkit-transform: rotate(-50deg);
+    -moz-transform: rotate(-50deg);
+    -ms-transform: rotate(-50deg);
+    -o-transform: rotate(-50deg);
+    transform: rotate(-50deg)
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel] table tr td[data-ax5grid-column-attr="rowSelector"][data-ax5grid-selected="true"] .checkBox:after {
+    opacity: 1
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel] table tr td [data-ax5grid-cellHolder] {
+    display: block;
+    box-sizing: border-box;
+    padding: 3px 5px;
+    font-size: 12px;
+    line-height: 1;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel] table tr td [data-ax5grid-cellHolder][data-ax5grid-text-align="left"] {
+    text-align: left
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel] table tr td [data-ax5grid-cellHolder][data-ax5grid-text-align="center"] {
+    text-align: center;
+    font-size: 12px;
+    font-weight: bold;
+    color: #5c5c5c;
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel] table tr td [data-ax5grid-cellHolder][data-ax5grid-text-align="right"] {
+    text-align: right
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel] table tr td [data-ax5grid-cellHolder][data-ax5grid-cellHolder="multiLine"] {
+    white-space: normal
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel] table tr td [data-ax5grid-cellHolder] [data-ax5grid-editor] {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    border: 0 none;
+    background: #fff
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel] table tr td [data-ax5grid-cellHolder] [data-ax5grid-editor]::-ms-clear {
+    display: none
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel] table tr td [data-ax5grid-cellHolder] [data-ax5select] {
+    position: absolute;
+    display: block;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    border: 0px none;
+    background: #fff
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel] table tr td [data-ax5grid-cellHolder] [data-ax5select] .ax5select-display {
+    height: 100%;
+    border-radius: 0
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel] table tr td [data-ax5grid-cellHolder] [data-ax5grid-editor="checkbox"] {
+    display: inline-block;
+    position: relative;
+    border-radius: 3px;
+    background-color: #EDF0F5;
+    height: 100%
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel] table tr td [data-ax5grid-cellHolder] [data-ax5grid-editor="checkbox"]:after {
+    content: '';
+    width: 60%;
+    height: 40%;
+    position: absolute;
+    top: 20%;
+    right: 20%;
+    border: 0.2em solid #3372ff;
+    border-top: none;
+    border-right: none;
+    background: transparent;
+    opacity: 0.0;
+    -webkit-transform: rotate(-50deg);
+    -moz-transform: rotate(-50deg);
+    -ms-transform: rotate(-50deg);
+    -o-transform: rotate(-50deg);
+    transform: rotate(-50deg)
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel] table tr td [data-ax5grid-cellHolder] [data-ax5grid-editor="checkbox"][data-ax5grid-checked="true"]:after {
+    opacity: 1.0
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel] table tr td [data-ax5grid-cellHolder] [data-ax5grid-tnode-arrow] {
+    display: inline-block;
+    box-sizing: content-box;
+    text-align: right;
+    text-shadow: 0 -1px #fff;
+    padding: 0 5px 0 0
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel] table tr td [data-ax5grid-cellHolder] a[data-ax5grid-tnode-arrow] {
+    cursor: pointer;
+    text-decoration: none
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel] table tr td [data-ax5grid-cellHolder] a[data-ax5grid-tnode-arrow]:hover {
+    text-decoration: none
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel] table tr td [data-ax5grid-cellHolder] [data-ax5grid-tnode-item="group"] {
+    display: inline-block
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel] table tr td [data-ax5grid-cellHolder] [data-ax5grid-tnode-item="item"] {
+    display: inline-block
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel][data-ax5grid-panel="aside-header"] {
+    /*border-right: 1px solid #ccc*/
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel][data-ax5grid-panel="aside-header"] table tr td {
+    text-align: center
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel][data-ax5grid-panel="top-aside-body"],[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel][data-ax5grid-panel="aside-body"],[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel][data-ax5grid-panel="bottom-aside-body"] {
+    /*border-right: 1px solid #ccc;*/
+    background: #EDF0F5
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel][data-ax5grid-panel="top-aside-body"] table tr,[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel][data-ax5grid-panel="aside-body"] table tr,[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel][data-ax5grid-panel="bottom-aside-body"] table tr {
+    background: #EDF0F5
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel][data-ax5grid-panel="top-aside-body"] table tr td,[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel][data-ax5grid-panel="aside-body"] table tr td,[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel][data-ax5grid-panel="bottom-aside-body"] table tr td {
+    text-align: center;
+    /*box-shadow: inset 1px 1px 0px 0px #fff*/
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel][data-ax5grid-panel="left-header"],[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel][data-ax5grid-panel="top-left-body"],[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel][data-ax5grid-panel="left-body"],[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel][data-ax5grid-panel="bottom-left-body"] {
+    /*border-right: 1px solid #b3b3b3*/
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel][data-ax5grid-panel="top-aside-body"],[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel][data-ax5grid-panel="top-left-body"],[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel][data-ax5grid-panel="top-body"],[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel][data-ax5grid-panel="top-right-body"] {
+    border-bottom: 1px solid #b3b3b3
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel][data-ax5grid-panel="bottom-aside-body"],[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel][data-ax5grid-panel="bottom-left-body"],[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel][data-ax5grid-panel="bottom-body"],[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel][data-ax5grid-panel="bottom-right-body"] {
+    border-top: 1px solid #b3b3b3
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel][data-ax5grid-panel="bottom-aside-body"],[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel][data-ax5grid-panel="bottom-left-body"],[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel][data-ax5grid-panel="bottom-body"],[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel][data-ax5grid-panel="bottom-right-body"] {
+    background-color: #EDF0F5;
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-panel] [data-ax5grid-panel-scroll] {
+    position: absolute;
+    left: 0;
+    top: 0
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-column-resizer] {
+    position: absolute;
+    right: 0;
+    top: 0;
+    width: 4px;
+    height: 100%;
+    background-color: #EDF0F5;
+    cursor: col-resize
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-column-resizer]:hover {
+    background-color: #EDF0F5;
+    opacity: 0.5
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-column-sort] {
+    position: relative;
+    width: 10px;
+    height: 10px;
+    display: inline-block;
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-column-sort]:before {
+    top: 0;
+    left: 0;
+    position: absolute;
+    content: ' ';
+    width: 0;
+    height: 0;
+    display: inline-block;
+    /*border-left: 3.6px solid transparent;*/
+    /*border-right: 3.6px solid transparent;*/
+    /*border-bottom: 4.09091px solid #000;*/
+    background: transparent;
+    opacity: .3
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-column-sort]:after {
+    bottom: 0;
+    left: 0;
+    position: absolute;
+    content: ' ';
+    width: 0;
+    height: 0;
+    display: inline-block;
+    /*border-left: 3.6px solid transparent;*/
+    /*border-right: 3.6px solid transparent;*/
+    /*border-top: 4.09091px solid #000;*/
+    background: transparent;
+    opacity: .3
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-column-sort][data-ax5grid-column-sort-order="asc"]:before {
+    top: 2px;
+    left: 0;
+    position: absolute;
+    content: ' ';
+    width: 0;
+    height: 0;
+    display: inline-block;
+    /*border-left: 4px solid transparent;*/
+    /*border-right: 4px solid transparent;*/
+    /*border-bottom: 5px solid #000;*/
+    background: transparent;
+    opacity: .8
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-column-sort][data-ax5grid-column-sort-order="asc"]:after {
+    display: none
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-column-sort][data-ax5grid-column-sort-order="desc"]:before {
+    display: none
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-column-sort][data-ax5grid-column-sort-order="desc"]:after {
+    bottom: 2px;
+    left: 0;
+    position: absolute;
+    content: ' ';
+    width: 0;
+    height: 0;
+    display: inline-block;
+    /*border-left: 4px solid transparent;*/
+    /*border-right: 4px solid transparent;*/
+    /*border-top: 5px solid #000;*/
+    background: transparent;
+    opacity: .8
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-column-filter] {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 10px;
+    height: 10px;
+    cursor: pointer
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="header"] [data-ax5grid-column-filter]:before {
+    content: ' ';
+    width: 0;
+    height: 0;
+    display: inline-block;
+    /*border-left: 5px solid transparent;*/
+    /*border-right: 5px solid transparent;*/
+    /*border-top: 10px solid #000;*/
+    background: transparent;
+    opacity: 1
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] {
+    margin: 0;
+    padding: 0;
+    position: relative;
+    overflow: hidden
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel] {
+    margin: 0;
+    padding: 0;
+    position: absolute;
+    overflow: hidden
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel] table {
+    table-layout: fixed;
+    border-collapse: separate;
+    border-spacing: 0;
+    border: 0 none;
+    width: 100%
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel] table tr {
+    border-bottom: 0 none
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel] table tr.tr-0 {
+    background: #f3f3f3
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel] table tr.tr-1 {
+    background: #fff
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel] table tr.tr-2 {
+    background: #f3f3f3
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel] table tr.tr-3 {
+    background: #fff
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel] table tr.hover {
+    background: #e1eef8
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel] table tr[data-ax5grid-grouping-tr="true"] {
+    background: #ffffe7
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel] table tr[data-ax5grid-selected="true"] {
+    background: #e3f1ff
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel] table tr[data-ax5grid-selected="true"] td[data-ax5grid-column-attr="rowSelector"],[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel] table tr[data-ax5grid-selected="true"] td[data-ax5grid-column-attr="lineNumber"] {
+    box-shadow: none
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel] table tr[data-ax5grid-selected="true"] td[data-ax5grid-column-attr="rowSelector"] .checkBox:after {
+    opacity: 1
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel] table tr[data-ax5grid-disable-selection="true"] td[data-ax5grid-column-attr="rowSelector"] .checkBox {
+    cursor: not-allowed;
+    background-color: #d7d7d7;
+    background-image: -webkit-linear-gradient(top, #d7d7d7,#e6e6e6);
+    background-image: linear-gradient(to bottom,#d7d7d7,#e6e6e6)
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel] table tr[data-ax5grid-disable-selection="true"] td[data-ax5grid-column-attr="rowSelector"] .checkBox:after {
+    opacity: 0
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel] table tr td.merged {
+    background: #fff
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel] table tr td {
+    box-sizing: border-box;
+    overflow: hidden;
+    position: relative;
+    padding: 0;
+    font-size: 12px;
+    border: 0 none
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel] table tr td.hasBorder {
+    border-right: 1px solid #ccc;
+    border-bottom: 1px solid #ccc
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel] table tr td.focused {
+    box-shadow: inset 0px 0px 1px 1px #0581f2
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel] table tr td[data-ax5grid-column-row="null"] {
+    border-right: 0 none
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel] table tr td[data-ax5grid-column-selected] {
+    background: #b1d7fe;
+    border-color: #ccc;
+    color: #000
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel] table tr td[data-ax5grid-column-focused] {
+    box-shadow: inset 0px 0px 1px 1px #0581f2;
+    background: #e3f1ff;
+    color: #000
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel] table tr td[data-ax5grid-column-attr="rowSelector"] {
+    cursor: pointer
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel] table tr td[data-ax5grid-column-attr="rowSelector"] .checkBox {
+    display: block;
+    position: relative;
+    border: 1px solid #ccc;
+    border-radius: 3px;
+    background-color: #fff;
+    background-image: -webkit-linear-gradient(top, #fff,#F0F0F0);
+    background-image: linear-gradient(to bottom,#fff,#F0F0F0);
+    height: 100%;
+    width: 100%
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel] table tr td[data-ax5grid-column-attr="rowSelector"] .checkBox:after {
+    content: '';
+    width: 60%;
+    height: 40%;
+    position: absolute;
+    top: 20%;
+    right: 20%;
+    border: 0.2em solid #3372ff;
+    border-top: none;
+    border-right: none;
+    background: transparent;
+    opacity: 0.0;
+    -webkit-transform: rotate(-50deg);
+    -moz-transform: rotate(-50deg);
+    -ms-transform: rotate(-50deg);
+    -o-transform: rotate(-50deg);
+    transform: rotate(-50deg)
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel] table tr td[data-ax5grid-column-attr="rowSelector"][data-ax5grid-selected="true"] .checkBox:after {
+    opacity: 1
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel] table tr td [data-ax5grid-cellHolder] {
+    display: block;
+    box-sizing: border-box;
+    padding: 3px 5px;
+    font-size: 12px;
+    line-height: 1;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel] table tr td [data-ax5grid-cellHolder][data-ax5grid-text-align="left"] {
+    text-align: left
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel] table tr td [data-ax5grid-cellHolder][data-ax5grid-text-align="center"] {
+    text-align: center
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel] table tr td [data-ax5grid-cellHolder][data-ax5grid-text-align="right"] {
+    text-align: right
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel] table tr td [data-ax5grid-cellHolder][data-ax5grid-cellHolder="multiLine"] {
+    white-space: normal
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel] table tr td [data-ax5grid-cellHolder] [data-ax5grid-editor] {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    border: 0 none;
+    background: #fff
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel] table tr td [data-ax5grid-cellHolder] [data-ax5grid-editor]::-ms-clear {
+    display: none
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel] table tr td [data-ax5grid-cellHolder] [data-ax5select] {
+    position: absolute;
+    display: block;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    border: 0px none;
+    background: #fff
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel] table tr td [data-ax5grid-cellHolder] [data-ax5select] .ax5select-display {
+    height: 100%;
+    border-radius: 0
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel] table tr td [data-ax5grid-cellHolder] [data-ax5grid-editor="checkbox"] {
+    display: inline-block;
+    position: relative;
+    border: 1px solid #ccc;
+    border-radius: 3px;
+    background-color: #fff;
+    background-image: -webkit-linear-gradient(top, #fff,#F0F0F0);
+    background-image: linear-gradient(to bottom,#fff,#F0F0F0);
+    height: 100%
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel] table tr td [data-ax5grid-cellHolder] [data-ax5grid-editor="checkbox"]:after {
+    content: '';
+    width: 60%;
+    height: 40%;
+    position: absolute;
+    top: 20%;
+    right: 20%;
+    border: 0.2em solid #3372ff;
+    border-top: none;
+    border-right: none;
+    background: transparent;
+    opacity: 0.0;
+    -webkit-transform: rotate(-50deg);
+    -moz-transform: rotate(-50deg);
+    -ms-transform: rotate(-50deg);
+    -o-transform: rotate(-50deg);
+    transform: rotate(-50deg)
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel] table tr td [data-ax5grid-cellHolder] [data-ax5grid-editor="checkbox"][data-ax5grid-checked="true"]:after {
+    opacity: 1.0
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel] table tr td [data-ax5grid-cellHolder] [data-ax5grid-tnode-arrow] {
+    display: inline-block;
+    box-sizing: content-box;
+    text-align: right;
+    text-shadow: 0 -1px #fff;
+    padding: 0 5px 0 0
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel] table tr td [data-ax5grid-cellHolder] a[data-ax5grid-tnode-arrow] {
+    cursor: pointer;
+    text-decoration: none
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel] table tr td [data-ax5grid-cellHolder] a[data-ax5grid-tnode-arrow]:hover {
+    text-decoration: none
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel] table tr td [data-ax5grid-cellHolder] [data-ax5grid-tnode-item="group"] {
+    display: inline-block
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel] table tr td [data-ax5grid-cellHolder] [data-ax5grid-tnode-item="item"] {
+    display: inline-block
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel][data-ax5grid-panel="aside-header"] {
+    border-right: 1px solid #ccc
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel][data-ax5grid-panel="aside-header"] table tr td {
+    text-align: center
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel][data-ax5grid-panel="top-aside-body"],[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel][data-ax5grid-panel="aside-body"],[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel][data-ax5grid-panel="bottom-aside-body"] {
+    border-right: 1px solid #ccc;
+    background: #f2f2f2
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel][data-ax5grid-panel="top-aside-body"] table tr,[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel][data-ax5grid-panel="aside-body"] table tr,[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel][data-ax5grid-panel="bottom-aside-body"] table tr {
+    background: #f2f2f2
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel][data-ax5grid-panel="top-aside-body"] table tr td,[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel][data-ax5grid-panel="aside-body"] table tr td,[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel][data-ax5grid-panel="bottom-aside-body"] table tr td {
+    text-align: center;
+    box-shadow: inset 1px 1px 0px 0px #fff
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel][data-ax5grid-panel="left-header"],[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel][data-ax5grid-panel="top-left-body"],[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel][data-ax5grid-panel="left-body"],[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel][data-ax5grid-panel="bottom-left-body"] {
+    border-right: 1px solid #b3b3b3
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel][data-ax5grid-panel="top-aside-body"],[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel][data-ax5grid-panel="top-left-body"],[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel][data-ax5grid-panel="top-body"],[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel][data-ax5grid-panel="top-right-body"] {
+    border-bottom: 1px solid #b3b3b3
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel][data-ax5grid-panel="bottom-aside-body"],[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel][data-ax5grid-panel="bottom-left-body"],[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel][data-ax5grid-panel="bottom-body"],[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel][data-ax5grid-panel="bottom-right-body"] {
+    border-top: 1px solid #b3b3b3
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel][data-ax5grid-panel="bottom-aside-body"],[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel][data-ax5grid-panel="bottom-left-body"],[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel][data-ax5grid-panel="bottom-body"],[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel][data-ax5grid-panel="bottom-right-body"] {
+    background: #ffe7e2
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="body"] [data-ax5grid-panel] [data-ax5grid-panel-scroll] {
+    position: absolute;
+    left: 0;
+    top: 0
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="page"] {
+    margin: 0;
+    padding: 0;
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    overflow: hidden;
+    background-color: #fff;
+    background-image: -webkit-linear-gradient(top, #fff,#F0F0F0);
+    background-image: linear-gradient(to bottom,#fff,#F0F0F0);
+    border: 0px none;
+    border-top: 1px solid #ccc
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="page"] [data-ax5grid-page="holder"] {
+    margin: 0;
+    padding: 0;
+    display: table;
+    width: 100%;
+    height: 100%
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="page"] [data-ax5grid-page="holder"] [data-ax5grid-page="navigation"] {
+    margin: 0;
+    padding: 0;
+    display: table-cell;
+    vertical-align: middle;
+    text-align: left;
+    padding-left: 5px;
+    font-size: 12px
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="page"] [data-ax5grid-page="holder"] [data-ax5grid-page="navigation"] [data-ax5grid-page-navigation="holder"] {
+    display: table
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="page"] [data-ax5grid-page="holder"] [data-ax5grid-page="navigation"] [data-ax5grid-page-navigation="holder"] [data-ax5grid-page-navigation="cell"],[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="page"] [data-ax5grid-page="holder"] [data-ax5grid-page="navigation"] [data-ax5grid-page-navigation="holder"] [data-ax5grid-page-navigation="cell-paging"] {
+    display: table-cell;
+    vertical-align: middle
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="page"] [data-ax5grid-page="holder"] [data-ax5grid-page="navigation"] [data-ax5grid-page-navigation="holder"] [data-ax5grid-page-navigation="cell-paging"] {
+    padding: 0 5px
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="page"] [data-ax5grid-page="holder"] [data-ax5grid-page="navigation"] [data-ax5grid-page-navigation="holder"] [data-ax5grid-page-move] {
+    box-sizing: border-box;
+    min-width: 20px;
+    border-radius: 5px;
+    padding: 1px;
+    border: 0px none;
+    background: transparent;
+    font-size: 11px;
+    color: #222;
+    outline: 0
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="page"] [data-ax5grid-page="holder"] [data-ax5grid-page="navigation"] [data-ax5grid-page-navigation="holder"] [data-ax5grid-page-move][data-ax5grid-page-selected="true"],[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="page"] [data-ax5grid-page="holder"] [data-ax5grid-page="navigation"] [data-ax5grid-page-navigation="holder"] [data-ax5grid-page-move]:active {
+    background-color: #888;
+    color: #fff
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="page"] [data-ax5grid-page="holder"] [data-ax5grid-page="navigation"] [data-ax5grid-page-navigation="holder"] [data-ax5grid-page-move]:hover {
+    text-decoration: underline
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="page"] [data-ax5grid-page="holder"] [data-ax5grid-page="status"] {
+    margin: 0;
+    padding: 0;
+    display: table-cell;
+    text-align: right;
+    vertical-align: middle;
+    padding-right: 10px;
+    font-size: 12px;
+    color: #222
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="scroller"] {
+    margin: 0;
+    padding: 0;
+    position: absolute;
+    right: 0px;
+    bottom: 0px
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="scroller"] [data-ax5grid-scroller="vertical"] {
+    box-sizing: border-box;
+    position: absolute;
+    display: none;
+    right: 0;
+    bottom: 0;
+    width: 15px;
+    height: 100%;
+    background: #f3f3f3;
+    border-left: 1px solid #ccc
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="scroller"] [data-ax5grid-scroller="vertical"] [data-ax5grid-scroller="vertical-bar"] {
+    position: absolute;
+    top: 0;
+    left: 0;
+    border-top-right-radius: 10px;
+    border-top-left-radius: 10px;
+    border-bottom-right-radius: 10px;
+    border-bottom-left-radius: 10px;
+    box-sizing: border-box;
+    border: 0px solid #fff;
+    background: #ccc;
+    cursor: ns-resize
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="scroller"] [data-ax5grid-scroller="vertical"] [data-ax5grid-scroller="vertical-bar"]:hover {
+    border: 0px solid #ccc;
+    background: #bababa
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="scroller"] [data-ax5grid-scroller="horizontal"] {
+    box-sizing: border-box;
+    position: absolute;
+    display: none;
+    right: 0;
+    bottom: 0;
+    height: 15px;
+    width: 100%;
+    background: #f3f3f3;
+    border-top: 1px solid #ccc
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="scroller"] [data-ax5grid-scroller="horizontal"] [data-ax5grid-scroller="horizontal-bar"] {
+    position: absolute;
+    top: 0;
+    left: 0;
+    border-top-right-radius: 10px;
+    border-top-left-radius: 10px;
+    border-bottom-right-radius: 10px;
+    border-bottom-left-radius: 10px;
+    box-sizing: border-box;
+    border: 0px solid #fff;
+    background: #ccc;
+    cursor: ew-resize
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="scroller"] [data-ax5grid-scroller="horizontal"] [data-ax5grid-scroller="horizontal-bar"]:hover {
+    border: 0px solid #ccc;
+    background: #bababa
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-container="scroller"] [data-ax5grid-scroller="corner"] {
+    position: absolute;
+    display: none;
+    right: 0px;
+    bottom: 0px;
+    width: 15px;
+    height: 15px;
+    background: #EAEDEF;
+    border-top: 1px solid #ccc;
+    border-left: 1px solid #ccc
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-resizer="horizontal"] {
+    display: none
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-resizer="horizontal"].live {
+    display: block;
+    position: absolute;
+    top: 0;
+    left: 0;
+    background: #f30;
+    opacity: 0.5;
+    height: 100%;
+    width: 2px;
+    cursor: col-resize
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-resizer="vertical"] {
+    display: none
+}
+
+[data-ax5grid] [data-ax5grid-container="root"] [data-ax5grid-resizer="vertical"].live {
+    display: block;
+    position: absolute;
+    top: 0;
+    left: 0;
+    background: #f30;
+    opacity: 0.5;
+    height: 2px;
+    width: 100%;
+    cursor: row-resize;
+}
+
+[data-ax5grid-container="header"] span {
+    font-size: 10px;
+}

--- a/src/main/webapp/resources/defect/css/defect.css
+++ b/src/main/webapp/resources/defect/css/defect.css
@@ -1,0 +1,159 @@
+@font-face {
+    font-family: 'Pretendard-Regular';
+    src: url('https://fastly.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff') format('woff');
+    font-weight: 500;
+    font-style: normal;
+}
+
+* {
+    font-family: 'Pretendard-Regular';
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+
+body {
+    padding: 30px;
+}
+
+label {
+    font-size: 15px;
+    font-weight: bolder;
+    color: #000;
+}
+
+input {
+    width: 95%;
+    height: 30px;
+    padding: 5px;
+    border-radius: 5px;
+}
+
+span {
+    font-size: 15px;
+    color: #4b4b4b;
+}
+
+.defect-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.defect-table td {
+    border: 1px solid #ccc;
+    padding: 9px;
+    width: 25%;
+    font-size: 14px;
+}
+
+td textarea {
+    width: 100%;
+    height: 200px;
+    padding: 10px;
+    resize: none;
+}
+
+.type {
+    padding: 2px;
+    width: 70%;
+    height: 30px;
+    border-radius: 5px;
+}
+
+.td-title {
+    background-color: #edf0f5;
+    font-weight: bolder;
+}
+
+.date {
+    padding: 2px;
+    width: 80%;
+    height: 30px;
+    border-radius: 5px;
+}
+
+.file-zone_1 .select-box, .file-zone_2 .select-box {
+    margin-left: 20px;
+    width: 250px;
+    height: 150px;
+    padding: 10px;
+    overflow-y: auto;
+}
+
+.file-zone_1 .dropzone, .file-zone_2 .dropzone {
+    border-radius: 5px;
+    width: 100%;
+    min-height: 30px;
+    padding: 10px;
+}
+
+.dropzone {
+    height: 50px;
+}
+
+.dropzone div {
+    margin: 0 !important;
+}
+
+.file-zone_1 .dropzone-preview .dz-preview, .file-zone_2 .dropzone-preview .dz-preview {
+    width: 150px;
+    margin: 5px;
+}
+
+.file-zone_1 .dropzone-preview .dz-preview .dz-filename, .file-zone_2 .dropzone-preview .dz-preview .dz-filename {
+    font-size: 12px;
+}
+
+.file-zone_1 .dropzone-preview .dz-preview .dz-size,
+.file-zone_1 .dropzone-preview .dz-preview .dz-error-message,
+.file-zone_2 .dropzone-preview .dz-preview .dz-size,
+.file-zone_2 .dropzone-preview .dz-preview .dz-error-message
+{
+    font-size: 10px;
+}
+
+.file-zone_1 .dropzone-preview li.dz-preview, .file-zone_2 .dropzone-preview li.dz-preview {
+    width: 100%;
+    margin: 5px 0;
+}
+
+.file-zone_1 .dropzone-preview .dz-preview, .file-zone_2 .dropzone-preview .dz-preview {
+    width: 100%;
+}
+
+.file-zone_1 .dropzone-preview .dz-preview .dz-image, .file-zone_2 .dropzone-preview .dz-preview .dz-image {
+    flex: 0 0 auto;
+    margin-right: 15px;
+}
+
+.file-zone_1 .dz-image img, .file-zone_2 .dz-image img {
+    width: 40px !important;
+    height: 40px;
+}
+
+.file-zone_1 .dropzone-preview .dz-preview .dz-details, .file-zone_2 .dropzone-preview .dz-preview .dz-details {
+    flex: 1 1 auto;
+    overflow: hidden;
+}
+
+.file-zone_1 .dropzone-preview .dz-preview .dz-remove, .file-zone_2 .dropzone-preview .dz-preview .dz-remove {
+    flex: 0 0 auto;
+    margin-left: 15px;
+}
+
+.file-zone_1 .dropzone-preview .dz-preview .dz-filename,
+.file-zone_1 .dropzone-preview .dz-preview .dz-size,
+.file-zone_2 .dropzone-preview .dz-preview .dz-filename,
+.file-zone_2 .dropzone-preview .dz-preview .dz-size {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.file-zone_1 .file-section, .file-zone_2 .file-section {
+    height: 150px;
+    border: 1px solid #C5C5C5;
+    padding: 10px;
+    overflow-y: auto;
+}

--- a/src/main/webapp/resources/defect/css/list.css
+++ b/src/main/webapp/resources/defect/css/list.css
@@ -1,0 +1,9 @@
+label {
+    font-size: 15px;
+    color: #000;
+}
+
+span {
+    display: flex;
+    justify-content: center !important;
+}

--- a/src/main/webapp/resources/defect/js/defect.js
+++ b/src/main/webapp/resources/defect/js/defect.js
@@ -1,31 +1,46 @@
 document.addEventListener('DOMContentLoaded', function() {
+    var defectActionContent = '${defectActionContent}';
+    var hasDefectActionContent = defectActionContent && defectActionContent.trim() !== '';
+
     if (Dropzone.instances.length > 0) {
         Dropzone.instances.forEach(function(dz) {
             dz.destroy();
         });
     }
 
+    // 첫 번째 Dropzone
     const dropzonePreviewNode = document.querySelector('.file-zone_1 .dropzone-preview-list');
-    const dropzonePreviewNode2 = document.querySelector('.file-zone_2 .dropzone-preview-list');
-    dropzonePreviewNode.id = '';
-    const previewTemplate = dropzonePreviewNode.parentNode.innerHTML;
-    dropzonePreviewNode.parentNode.removeChild(dropzonePreviewNode);
-    dropzonePreviewNode2.parentNode.removeChild(dropzonePreviewNode2);
+    if (dropzonePreviewNode) {
+        const previewTemplate = dropzonePreviewNode.parentNode.innerHTML;
+        dropzonePreviewNode.parentNode.removeChild(dropzonePreviewNode);
+        const dropzone = initDropzone('#df-insert-file-dropzone_1', '.file-zone_1', previewTemplate);
 
-    const dropzone = initDropzone('#df-insert-file-dropzone_1', '.file-zone_1', previewTemplate);
-    const dropzone2 = initDropzone('#df-insert-file-dropzone_2', '.file-zone_2', previewTemplate);
+        // 미구현 경로 임으로 임시로 처리
+        dropzone.processQueue = function() {
+            this.emit('queuecomplete');
+        };
 
-    $('.save-button').on('click', function(e) {
-        e.preventDefault();
-        dropzone.processQueue();
-        dropzone2.processQueue();
-    });
+        $('.save-button').on('click', function(e) {
+            e.preventDefault();
+            dropzone.processQueue();
+        });
+    }
 
-    // 미구현 경로 임으로 임시로 처리
-    dropzone.processQueue = function() {
-        this.emit('queuecomplete');
-    };
-    dropzone2.processQueue = function() {
-        this.emit('queuecomplete');
-    };
+    if (hasDefectActionContent) {
+        const dropzonePreviewNode2 = document.querySelector('.file-zone_2 .dropzone-preview-list');
+        if (dropzonePreviewNode2) {
+            const previewTemplate2 = dropzonePreviewNode2.parentNode.innerHTML;
+            dropzonePreviewNode2.parentNode.removeChild(dropzonePreviewNode2);
+            const dropzone2 = initDropzone('#df-insert-file-dropzone_2', '.file-zone_2', previewTemplate2);
+
+            dropzone2.processQueue = function() {
+                this.emit('queuecomplete');
+            };
+
+            $('.save-button').on('click', function(e) {
+                e.preventDefault();
+                dropzone2.processQueue();
+            });
+        }
+    }
 });

--- a/src/main/webapp/resources/defect/js/defect.js
+++ b/src/main/webapp/resources/defect/js/defect.js
@@ -1,0 +1,31 @@
+document.addEventListener('DOMContentLoaded', function() {
+    if (Dropzone.instances.length > 0) {
+        Dropzone.instances.forEach(function(dz) {
+            dz.destroy();
+        });
+    }
+
+    const dropzonePreviewNode = document.querySelector('.file-zone_1 .dropzone-preview-list');
+    const dropzonePreviewNode2 = document.querySelector('.file-zone_2 .dropzone-preview-list');
+    dropzonePreviewNode.id = '';
+    const previewTemplate = dropzonePreviewNode.parentNode.innerHTML;
+    dropzonePreviewNode.parentNode.removeChild(dropzonePreviewNode);
+    dropzonePreviewNode2.parentNode.removeChild(dropzonePreviewNode2);
+
+    const dropzone = initDropzone('#df-insert-file-dropzone_1', '.file-zone_1', previewTemplate);
+    const dropzone2 = initDropzone('#df-insert-file-dropzone_2', '.file-zone_2', previewTemplate);
+
+    $('.save-button').on('click', function(e) {
+        e.preventDefault();
+        dropzone.processQueue();
+        dropzone2.processQueue();
+    });
+
+    // 미구현 경로 임으로 임시로 처리
+    dropzone.processQueue = function() {
+        this.emit('queuecomplete');
+    };
+    dropzone2.processQueue = function() {
+        this.emit('queuecomplete');
+    };
+});

--- a/src/main/webapp/resources/defect/js/list.js
+++ b/src/main/webapp/resources/defect/js/list.js
@@ -1,0 +1,84 @@
+$(function () {
+    let testGrid = new ax5.ui.grid();
+
+    testGrid.setConfig({
+        target: $('[data-ax5grid="first-grid"]'),
+        columns: [
+            {key: "defect_id", label: "결함 ID", align: "center", width: 150, formatter: function() {
+                    let item = this.value;
+                    return '<input type=hidden name=defect_id value=${item.id} />' +
+                        '<a href="/projects/1/defects/' + encodeURIComponent(item.id) + '" class="defect-id" style="color: #2383f8; font-size: 13px; font-weight: bold; text-decoration: none;">' + item.value + '</a>';
+                }},
+            {key: "defect_title", label: "결함명", width: 300, align: "center" , formatter: function (){
+                    return '<span style="font-size: 13px;">' + this.value + '</span>';
+                }},
+            {key: "order", label: "우선순위", width: 70, align: "center", formatter: function (){
+                    return '<span style="font-size: 13px;">' + this.value + '</span>';
+                }},
+            {key: "discover", label: "발견자", width: 100, align: "center", formatter: function (){
+                    return '<span style="font-size: 13px;">' + this.value + '</span>';
+                }},
+            {key: "worker", label: "조치자", width: 100, align: "center", formatter: function (){
+                    return '<span style="font-size: 13px;">' + this.value + '</span>';
+                }},
+            {key: "discovered_date", label: "발견일자", width: 180, align: "center", formatter: function (){
+                    return '<span style="font-size: 13px;">' + this.value + '</span>';
+                }},
+            {key: "sche_work_date", label: "조치예정일자", width: 180, align: "center", formatter: function (){
+                    return '<span style="font-size: 13px;">' + this.value + '</span>';
+                }},
+            {key: "work_date", label: "조치일자", width: 180, align: "center", formatter: function (){
+                    return '<span style="font-size: 13px;">' + this.value + '</span>';
+                }},
+            {key: "defect_status", label: "상태", width: 100, align: "center", formatter: function (){
+                    const status = this.value;
+
+                    let statusClass;
+                    if (status === '진행중') {
+                        statusClass = 'green-status';
+                    } else if (status === '해결') {
+                        statusClass = 'blue-status';
+                    } else if (status === '취소') {
+                        statusClass = 'cancel-status';
+                    } else {
+                        statusClass = 'red-status';
+                    }
+
+                    return '<span class="' + statusClass + '" style="font-size: 12px;">' + this.value + '</span>';
+                }}
+        ],
+    });
+
+    let testResponses = [
+        {defect_id: {
+            value: "TT-AD-01",
+            id: 1
+            }, defect_title: "요구사항정의서 ID미부여 항목 발견", order: "상", discover: "박길동", worker: "홍길동", discovered_date: "2024.01.07 ~ 2024.01.11", sche_work_date: "2024.01.07 ~ 2024.01.11", work_date: "2024.01.07 ~ 2024.01.11", defect_status: "신규"},
+        {defect_id: "TT-AD-01", defect_title: "요구사항정의서 ID미부여 항목 발견", order: "상", discover: "박길동", worker: "홍길동", discovered_date: "2024.01.02 ~ 2024.01.06", sche_work_date: "2024.01.07 ~ 2024.01.11", work_date: "2024.01.07 ~ 2024.01.11", defect_status: "진행중"},
+        {defect_id: "UTC_RSTR110", defect_title: "요구사항정의서 ID미부여 항목 발견", order: "상", discover: "박길동", worker: "홍길동", discovered_date: "2024.01.07 ~ 2024.01.11", sche_work_date: "2024.01.07 ~ 2024.01.11", work_date: "2024.01.07 ~ 2024.01.11", defect_status: "해결"},
+        {defect_id: "UTC_RSTR110", defect_title: "요구사항정의서 ID미부여 항목 발견", order: "상", discover: "박길동", worker: "홍길동", discovered_date: "2024.01.07 ~ 2024.01.11", sche_work_date: "2024.01.07 ~ 2024.01.11", work_date: "2024.01.07 ~ 2024.01.11", defect_status: "취소"},
+        {defect_id: "UTC_RSTR110", defect_title: "요구사항정의서 ID미부여 항목 발견", order: "상", discover: "박길동", worker: "홍길동", discovered_date: "2024.01.07 ~ 2024.01.11", sche_work_date: "2024.01.07 ~ 2024.01.11", work_date: "2024.01.07 ~ 2024.01.11", defect_status: "취소"},
+        {defect_id: "UTC_RSTR110", defect_title: "요구사항정의서 ID미부여 항목 발견", order: "상", discover: "박길동", worker: "홍길동", discovered_date: "2024.01.07 ~ 2024.01.11", sche_work_date: "2024.01.07 ~ 2024.01.11", work_date: "2024.01.07 ~ 2024.01.11", defect_status: "취소"},
+        {defect_id: "UTC_RSTR110", defect_title: "요구사항정의서 ID미부여 항목 발견", order: "상", discover: "박길동", worker: "홍길동", discovered_date: "2024.01.07 ~ 2024.01.11", sche_work_date: "2024.01.07 ~ 2024.01.11", work_date: "2024.01.07 ~ 2024.01.11", defect_status: "진행중"},
+        {defect_id: "UTC_RSTR110", defect_title: "요구사항정의서 ID미부여 항목 발견", order: "상", discover: "박길동", worker: "홍길동", discovered_date: "2024.01.07 ~ 2024.01.11", sche_work_date: "2024.01.07 ~ 2024.01.11", work_date: "2024.01.07 ~ 2024.01.11", defect_status: "진행중"},
+        {defect_id: "UTC_RSTR110", defect_title: "요구사항정의서 ID미부여 항목 발견", order: "상", discover: "박길동", worker: "홍길동", discovered_date: "2024.01.07 ~ 2024.01.11", sche_work_date: "2024.01.07 ~ 2024.01.11", work_date: "2024.01.07 ~ 2024.01.11", defect_status: "진행중"},
+        {defect_id: "UTC_RSTR110", defect_title: "요구사항정의서 ID미부여 항목 발견", order: "상", discover: "박길동", worker: "홍길동", discovered_date: "2024.01.07 ~ 2024.01.11", sche_work_date: "2024.01.07 ~ 2024.01.11", work_date: "2024.01.07 ~ 2024.01.11", defect_status: "진행중"},
+    ];
+    testGrid.setData(testResponses);
+
+    // 그리드 데이터 가져오기
+    /*
+    $.ajax({
+        method: "GET",
+        url: API_SERVER + "/api/v1/ax5grid",
+        success: function (res) {
+            firstGrid.setData(res);
+        }
+    });
+    */
+
+    $(document).on('click', '.defect-id', function(e) {
+        e.preventDefault();
+       let popup = window.open($(this).attr('href'), 'popup', 'width=800, height=600');
+    });
+});


### PR DESCRIPTION
# 작업 내용
- 결결함 관리 목록 페이지의 UI와 로직을 구현합니다.
- 결함 상세 페이지의 UI와 로직을 구현합니다.
- 상세 페이지의 경우 팝업으로 띄워지도록 합니다.

# To Reviewers
- 상세 페이지 연결의 경우 1번 row만 적용되어있습니다. 테스트는 1번으로 진행해주시면 감사하겠습니다.

# Screen Shot (선택)
![image](https://github.com/user-attachments/assets/00bdf137-88d7-4bbf-98c6-72bac4b492cf)
![image](https://github.com/user-attachments/assets/637b33db-9936-4068-bc70-70edea2152c0)

# Issue
- resolved: #55 
