### PR TITLE
[#56] 프로젝트 총인원 목록 조회 서버 로직 구현 

### DIFF
--- a/src/main/java/com/kcc/pms/domain/member/controller/MemberController.java
+++ b/src/main/java/com/kcc/pms/domain/member/controller/MemberController.java
@@ -2,7 +2,9 @@ package com.kcc.pms.domain.member.controller;
 
 import com.kcc.pms.domain.member.model.dto.GroupMembersResponseDto;
 import com.kcc.pms.domain.member.model.dto.GroupResponseDto;
+import com.kcc.pms.domain.member.model.dto.ProjectMemberResponseDto;
 import com.kcc.pms.domain.member.service.MemberService;
+import com.kcc.pms.domain.member.model.dto.MemberResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -39,5 +41,23 @@ public class MemberController {
     @ResponseBody
     public List<GroupMembersResponseDto> groupMembers(@RequestParam Long groupNo) {
         return memberService.getGroupMembers(groupNo);
+    }
+
+    @GetMapping("/members/team")
+    @ResponseBody
+    public List<MemberResponseDto> teamMembers(@RequestParam Long teamNo) {
+        return memberService.getTeamMember(teamNo);
+    }
+
+    @GetMapping("/projectmembers")
+    @ResponseBody
+    public List<ProjectMemberResponseDto> projectMembers(@RequestParam Long projectNo) {
+        return memberService.getProjectMemberList(projectNo);
+    }
+
+    @GetMapping("/members/detail")
+    @ResponseBody
+    public MemberResponseDto memberDetail(@RequestParam Long memberNo) {
+        return memberService.getMemberDetail(memberNo);
     }
 }

--- a/src/main/java/com/kcc/pms/domain/member/mapper/MemberMapper.java
+++ b/src/main/java/com/kcc/pms/domain/member/mapper/MemberMapper.java
@@ -2,6 +2,8 @@ package com.kcc.pms.domain.member.mapper;
 
 import com.kcc.pms.domain.member.model.dto.GroupMembersResponseDto;
 import com.kcc.pms.domain.member.model.dto.GroupResponseDto;
+import com.kcc.pms.domain.member.model.dto.MemberResponseDto;
+import com.kcc.pms.domain.member.model.dto.ProjectMemberResponseDto;
 import org.apache.ibatis.annotations.Mapper;
 
 import java.util.List;
@@ -10,4 +12,7 @@ import java.util.List;
 public interface MemberMapper {
     List<GroupResponseDto> getGroupList();
     List<GroupMembersResponseDto> getGroupMemberList(Long groupNo);
+    List<ProjectMemberResponseDto> getProjectMemberList(Long projectNo);
+    List<MemberResponseDto> getTeamMember(Long teamNo);
+    MemberResponseDto getMemberDetail(Long memberNo);
 }

--- a/src/main/java/com/kcc/pms/domain/member/model/dto/GroupMembersResponseDto.java
+++ b/src/main/java/com/kcc/pms/domain/member/model/dto/GroupMembersResponseDto.java
@@ -12,7 +12,7 @@ public class GroupMembersResponseDto implements Serializable {
     private String memberName;
     private String phoneNo;
     private String email;
-    private String positionName;
-    private String techGrade;
+    private String position;
+    private String tech;
     private String groupName;
 }

--- a/src/main/java/com/kcc/pms/domain/member/model/dto/MemberResponseDto.java
+++ b/src/main/java/com/kcc/pms/domain/member/model/dto/MemberResponseDto.java
@@ -1,0 +1,27 @@
+package com.kcc.pms.domain.member.model.dto;
+
+import com.kcc.pms.domain.team.model.vo.Team;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+public class MemberResponseDto implements Serializable {
+    private Long id;
+    private String memberName;
+    private String auth;
+    private String groupName;
+    private String position;
+    private String preStartDate;
+    private String preEndDate;
+    private String startDate;
+    private String endDate;
+    private String tech;
+    private String email;
+    private String phoneNo;
+    List<Team> connectTeams = new ArrayList<>();
+}

--- a/src/main/java/com/kcc/pms/domain/member/model/dto/ProjectMemberResponseDto.java
+++ b/src/main/java/com/kcc/pms/domain/member/model/dto/ProjectMemberResponseDto.java
@@ -1,16 +1,13 @@
-package com.kcc.pms.domain.team.model.dto;
+package com.kcc.pms.domain.member.model.dto;
 
-import com.kcc.pms.domain.team.model.vo.Team;
 import lombok.Getter;
 import lombok.Setter;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
 
 @Getter
 @Setter
-public class TeamMemberResponseDto implements Serializable {
+public class ProjectMemberResponseDto implements Serializable {
     private Long id;
     private String memberName;
     private String auth;
@@ -21,7 +18,5 @@ public class TeamMemberResponseDto implements Serializable {
     private String startDate;
     private String endDate;
     private String tech;
-    private String email;
-    private String phoneNo;
-    List<Team> connectTeams = new ArrayList<>();
+    private String teamName;
 }

--- a/src/main/java/com/kcc/pms/domain/member/service/MemberService.java
+++ b/src/main/java/com/kcc/pms/domain/member/service/MemberService.java
@@ -2,10 +2,15 @@ package com.kcc.pms.domain.member.service;
 
 import com.kcc.pms.domain.member.model.dto.GroupMembersResponseDto;
 import com.kcc.pms.domain.member.model.dto.GroupResponseDto;
+import com.kcc.pms.domain.member.model.dto.MemberResponseDto;
+import com.kcc.pms.domain.member.model.dto.ProjectMemberResponseDto;
 
 import java.util.List;
 
 public interface MemberService {
     List<GroupResponseDto> getGroupList();
     List<GroupMembersResponseDto> getGroupMembers(Long groupNo);
+    List<ProjectMemberResponseDto> getProjectMemberList(Long projectNo);
+    List<MemberResponseDto> getTeamMember(Long teamNo);
+    MemberResponseDto getMemberDetail(Long memberNo);
 }

--- a/src/main/java/com/kcc/pms/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/kcc/pms/domain/member/service/MemberServiceImpl.java
@@ -3,6 +3,9 @@ package com.kcc.pms.domain.member.service;
 import com.kcc.pms.domain.member.mapper.MemberMapper;
 import com.kcc.pms.domain.member.model.dto.GroupMembersResponseDto;
 import com.kcc.pms.domain.member.model.dto.GroupResponseDto;
+import com.kcc.pms.domain.member.model.dto.MemberResponseDto;
+import com.kcc.pms.domain.member.model.dto.ProjectMemberResponseDto;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -25,6 +28,21 @@ public class MemberServiceImpl implements MemberService{
     @Override
     public List<GroupMembersResponseDto> getGroupMembers(Long groupNo) {
         return mapper.getGroupMemberList(groupNo);
+    }
+
+    @Override
+    public List<ProjectMemberResponseDto> getProjectMemberList(Long projectNo) {
+        return mapper.getProjectMemberList(projectNo);
+    }
+
+    @Override
+    public List<MemberResponseDto> getTeamMember(Long teamNo) {
+        return mapper.getTeamMember(teamNo);
+    }
+
+    @Override
+    public MemberResponseDto getMemberDetail(Long memberNo) {
+        return mapper.getMemberDetail(memberNo);
     }
 
 

--- a/src/main/java/com/kcc/pms/domain/team/controller/TeamController.java
+++ b/src/main/java/com/kcc/pms/domain/team/controller/TeamController.java
@@ -1,6 +1,5 @@
 package com.kcc.pms.domain.team.controller;
 
-import com.kcc.pms.domain.team.model.dto.TeamMemberResponseDto;
 import com.kcc.pms.domain.team.model.dto.TeamResponseDto;
 import com.kcc.pms.domain.team.service.TeamService;
 import lombok.RequiredArgsConstructor;
@@ -22,9 +21,4 @@ public class TeamController {
         return teamService.getTeamList(projectNo);
     }
 
-    @GetMapping("/members")
-    @ResponseBody
-    public List<TeamMemberResponseDto> getMemberList(@RequestParam("teamNo") Long teamNo) {
-        return teamService.getTeamMember(teamNo);
-    }
 }

--- a/src/main/java/com/kcc/pms/domain/team/mapper/TeamMapper.java
+++ b/src/main/java/com/kcc/pms/domain/team/mapper/TeamMapper.java
@@ -1,6 +1,5 @@
 package com.kcc.pms.domain.team.mapper;
 
-import com.kcc.pms.domain.team.model.dto.TeamMemberResponseDto;
 import com.kcc.pms.domain.team.model.dto.TeamResponseDto;
 import org.apache.ibatis.annotations.Mapper;
 
@@ -9,5 +8,4 @@ import java.util.List;
 @Mapper
 public interface TeamMapper {
     List<TeamResponseDto> getTeamList(Long projectNo);
-    List<TeamMemberResponseDto> getTeamMember(Long teamNo);
 }

--- a/src/main/java/com/kcc/pms/domain/team/model/dto/TeamResponseDto.java
+++ b/src/main/java/com/kcc/pms/domain/team/model/dto/TeamResponseDto.java
@@ -17,5 +17,6 @@ public class TeamResponseDto implements Serializable {
     private Integer totalCount;
     private String systemName;
     private Integer parentId;
+    private int orderNo;
     private List<TeamResponseDto> children = new ArrayList<>();
 }

--- a/src/main/java/com/kcc/pms/domain/team/service/TeamService.java
+++ b/src/main/java/com/kcc/pms/domain/team/service/TeamService.java
@@ -1,11 +1,9 @@
 package com.kcc.pms.domain.team.service;
 
-import com.kcc.pms.domain.team.model.dto.TeamMemberResponseDto;
 import com.kcc.pms.domain.team.model.dto.TeamResponseDto;
 
 import java.util.List;
 
 public interface TeamService {
     List<TeamResponseDto> getTeamList(Long projectNo);
-    List<TeamMemberResponseDto> getTeamMember(Long teamNo);
 }

--- a/src/main/java/com/kcc/pms/domain/team/service/TeamServiceImpl.java
+++ b/src/main/java/com/kcc/pms/domain/team/service/TeamServiceImpl.java
@@ -1,16 +1,11 @@
 package com.kcc.pms.domain.team.service;
 
-import com.kcc.pms.domain.member.model.dto.GroupResponseDto;
 import com.kcc.pms.domain.team.mapper.TeamMapper;
-import com.kcc.pms.domain.team.model.dto.TeamMemberResponseDto;
 import com.kcc.pms.domain.team.model.dto.TeamResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -22,10 +17,6 @@ public class TeamServiceImpl implements TeamService{
         return buildTree(mapper.getTeamList(projectNo));
     }
 
-    @Override
-    public List<TeamMemberResponseDto> getTeamMember(Long teamNo) {
-        return mapper.getTeamMember(teamNo);
-    }
 
     public List<TeamResponseDto> buildTree(List<TeamResponseDto> nodeList) {
         Map<Integer, TeamResponseDto> nodeMap = new HashMap<>();
@@ -40,13 +31,16 @@ public class TeamServiceImpl implements TeamService{
             if (node.getParentId() == null) {
                 rootNodes.add(node);
             } else {
-                TeamResponseDto parent = nodeMap.get(node.getParentId()); //부모 존재 시 부모 노드에 자기자신 추가
+                TeamResponseDto parent = nodeMap.get(node.getParentId());
+                // 부모가 존재할 경우 자식으로 추가하고 정렬
                 if (parent != null) {
                     parent.getChildren().add(node);
+                    parent.getChildren().sort(Comparator.comparing(TeamResponseDto::getOrderNo));
                 }
             }
         }
 
+        rootNodes.sort(Comparator.comparing(TeamResponseDto::getOrderNo));
         return rootNodes;
     }
 }

--- a/src/main/resources/mapper/MemberMapper.xml
+++ b/src/main/resources/mapper/MemberMapper.xml
@@ -12,14 +12,139 @@
     </select>
 
     <select id="getGroupMemberList" resultType="com.kcc.pms.domain.member.model.dto.GroupMembersResponseDto">
-        select m.grp_no, m.mem_no as id, m.mem_nm as memberName, m.phone_no as phoneNo , m.email, tech_cd.cd_dtl_nm as techGrade,
-               pos_cd.cd_dtl_nm as positionName, g.grp_nm as groupName
+        select m.grp_no, m.mem_no as id, m.mem_nm as memberName, m.phone_no as phoneNo , m.email, tech_cd.cd_dtl_nm as tech,
+               pos_cd.cd_dtl_nm as position, g.grp_nm as groupName
         from member m, codedetail tech_cd, codedetail pos_cd, usergroup g
         where m.tech_grd_cd = tech_cd.cd_dtl_no
           and m.pos_nm = pos_cd.cd_dtl_no
           and m.grp_no = g.grp_no
           and m.grp_no = #{groupNo}
         order by pos_cd.order_no, tech_cd.order_no
+    </select>
+
+
+    <select id="getProjectMemberList" resultType="com.kcc.pms.domain.member.model.dto.ProjectMemberResponseDto">
+        SELECT m.mem_no AS id,
+               m.mem_nm AS memberName,
+               auth.cd_dtl_nm AS auth,
+               g.grp_nm AS groupName,
+               pos.cd_dtl_nm AS position,
+               pm.pre_start_dt AS preStartDate,
+               pm.pre_end_dt AS preEndDate,
+               pm.start_dt AS startDate,
+               pm.end_dt AS endDate,
+               tech.cd_dtl_nm AS tech,
+               t.tm_nm AS teamName
+        FROM projectmember pm,
+             member m,
+             usergroup g,
+             codedetail tech,
+             codedetail pos,
+             codedetail auth,
+             team t
+        WHERE pm.mem_no = m.mem_no
+          AND m.grp_no = g.grp_no
+          AND m.tech_grd_cd = tech.cd_dtl_no
+          AND m.pos_nm = pos.cd_dtl_no
+          AND pm.prj_auth_cd = auth.cd_dtl_no
+          AND pm.tm_no = t.tm_no
+          AND pm.tm_no IN (
+            SELECT t2.tm_no
+            FROM team t2
+            WHERE t2.prj_no = #{projectNo}
+        ) ORDER BY t.tm_no
+    </select>
+
+
+    <resultMap id="memberDetail" type="com.kcc.pms.domain.member.model.dto.MemberResponseDto">
+        <id column="MEM_NO" property="id" />
+        <result column="MEM_NM" property="memberName" />
+        <result column="AUTH" property="auth" />
+        <result column="GRP_NM" property="groupName" />
+        <result column="POSITION" property="position" />
+        <result column="PRE_START_DT" property="preStartDate" />
+        <result column="PRE_END_DT" property="preEndDate" />
+        <result column="START_DT" property="startDate" />
+        <result column="END_DT" property="endDate" />
+        <result column="TECH" property="tech" />
+        <result column="EMAIL" property="email" />
+        <result column="PHONE_NO" property="phoneNo" />
+
+        <collection property="connectTeams" resultMap="connectTeams"/>
+    </resultMap>
+
+    <resultMap id="connectTeams" type="com.kcc.pms.domain.team.model.vo.Team">
+        <result column="TM_NO" property="teamNo" />
+        <result column="TM_NM" property="teamName" />
+    </resultMap>
+
+
+    <select id="getMemberDetail" resultMap="memberDetail">
+        SELECT m.mem_no,
+               m.mem_nm,
+               auth.cd_dtl_nm AS AUTH,
+               g.grp_nm,
+               pos.cd_dtl_nm AS POSITION,
+               pm.pre_start_dt,
+               pm.pre_end_dt,
+               pm.start_dt,
+               pm.end_dt,
+               m.email,
+               m.phone_no,
+               tech.cd_dtl_nm AS TECH,
+               t.tm_no,
+               t.tm_nm
+        FROM projectmember pm,
+             member m,
+             usergroup g,
+             codedetail tech,
+             codedetail pos,
+             codedetail auth,
+             team t
+        WHERE pm.mem_no = m.mem_no
+          AND m.grp_no = g.grp_no
+          AND m.tech_grd_cd = tech.cd_dtl_no
+          AND m.pos_nm = pos.cd_dtl_no
+          AND pm.prj_auth_cd = auth.cd_dtl_no
+          AND pm.tm_no = t.tm_no
+          AND m.mem_no = #{memberNo}
+    </select>
+
+
+
+    <select id="getTeamMember" resultMap="memberDetail">
+        SELECT m.mem_no,
+               m.mem_nm,
+               auth.cd_dtl_nm as AUTH,
+               gr.grp_nm,
+               pos.cd_dtl_nm as POSITION,
+               pm.pre_start_dt,
+               pm.pre_end_dt,
+               pm.start_dt,
+               pm.end_dt,
+               tech.cd_dtl_nm as TECH,
+               m.email,
+               m.phone_no,
+               pmt.tm_no,
+               pmt.tm_nm
+        FROM projectmember pm,
+             member m,
+             usergroup gr,
+             codedetail auth,
+             codedetail pos,
+             codedetail tech,
+             (SELECT t.tm_no, t.tm_nm, pm.mem_no
+              FROM team t, projectmember pm
+              WHERE t.tm_no = pm.tm_no
+                AND t.par_tm_no IS NOT NULL
+             ) pmt
+        WHERE pm.prj_auth_cd = auth.cd_dtl_no AND
+            m.tech_grd_cd = tech.cd_dtl_no AND
+            m.pos_nm = pos.cd_dtl_no AND
+            pm.mem_no = m.mem_no AND
+            m.grp_no = gr.grp_no AND
+            pm.mem_no = pmt.mem_no AND
+            pm.tm_no = #{teamNo}
     </select>
 
 </mapper>

--- a/src/main/resources/mapper/TeamMapper.xml
+++ b/src/main/resources/mapper/TeamMapper.xml
@@ -11,80 +11,38 @@
                t.tm_nm as title,
                t.tm_cont as teamDescription,
                pt.tm_nm as parentTeamName,
-               NVL(pm.cnt, 0) as totalCount,
+               NVL(
+                       CASE
+                           WHEN t.par_tm_no IS NULL THEN
+                               (SELECT SUM(cnt)
+                                FROM (SELECT tm_no, COUNT(*) as cnt
+                                      FROM projectmember
+                                      GROUP BY tm_no
+                                     ) pm
+                                WHERE pm.tm_no IN (
+                                    SELECT t2.tm_no
+                                    FROM team t2
+                                    WHERE t2.prj_no = t.prj_no
+                                    START WITH t2.tm_no = t.tm_no
+                                    CONNECT BY PRIOR t2.tm_no = t2.par_tm_no
+                                )
+                               )
+                           ELSE
+                               (SELECT COUNT(*)
+                                FROM projectmember pm2
+                                WHERE pm2.tm_no = t.tm_no
+                               )
+                           END, 0) as totalCount,
                s.sys_ttl as systemName,
                t.par_tm_no as parentId,
-               t.order_no
+               t.order_no as orderNo
         FROM team t,
              system s,
-             team pt,
-             (SELECT tm_no, COUNT(*) cnt
-              FROM projectmember
-              GROUP BY tm_no) pm
+             team pt
         WHERE t.sys_no = s.sys_no(+)
           AND t.par_tm_no = pt.tm_no(+)
-          AND t.tm_no = pm.tm_no(+)
           AND t.prj_no = #{projectNo}
         ORDER BY NVL(t.par_tm_no, t.tm_no), t.order_no
     </select>
 
-
-
-
-    <resultMap id="teamMemberDetail" type="com.kcc.pms.domain.team.model.dto.TeamMemberResponseDto">
-        <id column="MEM_NO" property="id" />
-        <result column="MEM_NM" property="memberName" />
-        <result column="AUTH" property="auth" /> <!-- 프로젝트 권한 -->
-        <result column="GRP_NM" property="groupName" /> <!-- 소속 그룹 -->
-        <result column="POSITION" property="position" /> <!-- 직위 -->
-        <result column="PRE_START_DT" property="preStartDate" />
-        <result column="PRE_END_DT" property="preEndDate" />
-        <result column="START_DT" property="startDate" />
-        <result column="END_DT" property="endDate" />
-        <result column="TECH" property="tech" /> <!-- 기술 등급 -->
-        <result column="EMAIL" property="email" />
-        <result column="PHONE_NO" property="phoneNo" />
-
-        <collection property="connectTeams" resultMap="connectTeams"/>
-    </resultMap>
-
-    <resultMap id="connectTeams" type="com.kcc.pms.domain.team.model.vo.Team">
-        <result column="TM_NO" property="teamNo" />
-        <result column="TM_NM" property="teamName" />
-    </resultMap>
-
-    <select id="getTeamMember" resultMap="teamMemberDetail">
-        SELECT m.mem_no,
-               m.mem_nm,
-               auth.cd_dtl_nm as AUTH,
-               gr.grp_nm,
-               pos.cd_dtl_nm as POSITION,
-               pm.pre_start_dt,
-               pm.pre_end_dt,
-               pm.start_dt,
-               pm.end_dt,
-               tech.cd_dtl_nm as TECH,
-               m.email,
-               m.phone_no,
-               pmt.tm_no,
-               pmt.tm_nm
-        FROM projectmember pm,
-             member m,
-             usergroup gr,
-             codedetail auth,
-             codedetail pos,
-             codedetail tech,
-             (SELECT t.tm_no, t.tm_nm, pm.mem_no
-              FROM team t, projectmember pm
-              WHERE t.tm_no = pm.tm_no
-                AND t.par_tm_no IS NOT NULL
-             ) pmt
-        WHERE pm.prj_auth_cd = auth.cd_dtl_no AND
-            m.tech_grd_cd = tech.cd_dtl_no AND
-            m.pos_nm = pos.cd_dtl_no AND
-            pm.mem_no = m.mem_no AND
-            m.grp_no = gr.grp_no AND
-            pm.mem_no = pmt.mem_no AND
-            pm.tm_no = #{teamNo}
-    </select>
 </mapper>

--- a/src/main/webapp/WEB-INF/views/member/list.jsp
+++ b/src/main/webapp/WEB-INF/views/member/list.jsp
@@ -1,32 +1,32 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 
 <%@ include file="../common.jsp" %>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jstree/3.3.12/themes/default/style.min.css" />
 <!-- ax5ui -->
 <link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/ax5ui/ax5ui-calendar/master/dist/ax5calendar.css">
 <link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/ax5ui/ax5ui-picker/master/dist/ax5picker.css">
 <link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/ax5ui/ax5ui-select/master/dist/ax5select.css">
-
-<script src="https://code.jquery.com/jquery-latest.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+<%--<script src="https://code.jquery.com/jquery-latest.min.js"></script>--%>
 <script type="text/javascript" src="https://cdn.rawgit.com/ax5ui/ax5core/master/dist/ax5core.min.js"></script>
 <script type="text/javascript" src="https://cdn.rawgit.com/ax5ui/ax5ui-calendar/master/dist/ax5calendar.min.js"></script>
 <script type="text/javascript" src="https://cdn.rawgit.com/ax5ui/ax5ui-picker/master/dist/ax5picker.min.js"></script>
 <script type="text/javascript" src="https://cdn.rawgit.com/ax5ui/ax5ui-formatter/master/dist/ax5formatter.min.js"></script>
 <script type="text/javascript" src="https://cdn.rawgit.com/ax5ui/ax5ui-select/master/dist/ax5select.min.js"></script>
 <script type="text/javascript" src="https://cdn.rawgit.com/ax5ui/ax5ui-grid/master/dist/ax5grid.min.js"></script>
-<!--  -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jstree/3.3.12/jstree.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jstree/3.3.12/jstree.search.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jstree/3.3.12/jstree.dnd.min.js"></script>
 
+<%--<link href="https://cdnjs.cloudflare.com/ajax/libs/jquery.fancytree/2.38.1/skin-win8/ui.fancytree.min.css" rel="stylesheet">--%>
+<%--<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.fancytree/2.38.1/jquery.fancytree-all-deps.min.js"></script>--%>
+<%--<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.fancytree/2.38.1/modules/jquery.fancytree.table.min.js"></script>--%>
+<%--<script src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"></script>--%>
+<%--<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.fancytree/2.38.1/modules/jquery.fancytree.filter.min.js"></script>--%>
 
 <link href="https://cdnjs.cloudflare.com/ajax/libs/jquery.fancytree/2.38.1/skin-win8/ui.fancytree.min.css" rel="stylesheet">
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.fancytree/2.38.1/jquery.fancytree-all-deps.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.fancytree/2.38.1/modules/jquery.fancytree.table.min.js"></script>
 <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.fancytree/2.38.1/modules/jquery.fancytree.filter.min.js"></script>
+
 
 <link rel="stylesheet" href="../../../resources/member/css/list.css">
 <link rel="stylesheet" href="../../../resources/member/css/ax5grid.css">
@@ -68,7 +68,23 @@
             </div>
 
             <div class="main-content">
-                <h2 class="header1"><span class="member-title">인력</span> 2</h2>
+                <h2 class="header1"><span class="member-title">인력</span> </h2>
+
+                <div id="project-member-grid-section" style="display:none;">
+                    <div class="team-overview-title">
+                        <div class="team-title">전체 투입 인력 목록</div>
+                        <div class="btn-group">
+                            <button class="">삭제</button>
+                            <button class="member-edit-button">편집</button>
+                            <button class="">그룹등록</button>
+                            <button class="" onclick="openGroupPopup()">인력등록</button>
+                        </div>
+                    </div>
+                    <div style="position: relative;height:270px;" id="grid-parent1">
+                        <div data-ax5grid="projectMemberGrid" data-ax5grid-config="{}" style="height: 100%;"></div>
+                    </div>
+                </div>
+
 
                 <div class="team-overview">
                     <div class="team-overview-title">
@@ -109,6 +125,7 @@
                             <button class="">참여시작</button>
                             <button class="">참여종료</button>
                             <button class="">해제</button>
+                            <button class="member-edit-button">편집</button>
                             <button class="" onclick="openGroupPopup()">인력등록</button>
                         </div>
                     </div>

--- a/src/main/webapp/resources/member/css/list.css
+++ b/src/main/webapp/resources/member/css/list.css
@@ -70,6 +70,7 @@
 }
 
 .member-detail {
+    margin-top: 50px;
     display: none;
 }
 
@@ -198,4 +199,8 @@
 
 .clickable-name:hover {
     color: darkblue;
+}
+
+.ax5grid-body {
+    font-size: 14px;
 }

--- a/src/main/webapp/resources/member/js/list.js
+++ b/src/main/webapp/resources/member/js/list.js
@@ -1,36 +1,36 @@
 var teamMemberGrid;
+var projectMemberGrid;
 var editMode = false;
+let isEditing = false;
 var projectNo = 1;
 $(document).ready(function() {
-    loadTeamData(projectNo);  // 처음 로드 시 team 데이터를 불러오는 함수 호출
+
 
     $("#btnEdit").click(function () {
         toggleEditMode();  // 편집 모드 토글 함수
     });
 
-    teamMemberGrid = new ax5.ui.grid();
-    teamMemberGrid.setConfig({
-        showRowSelector: true,
-        target: $('[data-ax5grid="teamMemberGrid"]'),
-        columns: [
-            {key: "memberName", label: "성명", align: "center", formatter: function() {
-                    return '<a href="#" class="clickable-name member-link" data-id="' + this.item.id + '">' + this.value + '</a>';
-            }},
-            {key: "auth", label: "프로젝트 권환", align: "center" },
-            {key: "groupName", width: 110, label: "소속", align: "center"},
-            {key: "position", width: 80, label: "직위",align: "center"},
-            {key: "preStartDate", width: 120, label: "예정시작일",align: "center"},
-            {key: "preEndDate", width:120, label: "예정종료일", align: "center"},
-            {key: "startDate", width: 120, label: "참여시작일", align: "center" },
-            {key: "endDate", width: 120, label: "참여종료일", align: "center"},
-            {key: "tech", width: 80, label: "기술등급",align: "center"}
-        ],
-        page: {
-            display: false
+    // 편집 버튼
+    $('.member-edit-button').on('click', function () {
+        var currentText = $(this).text();
+
+        if (currentText === '편집') {
+            isEditing = true;
+            $(this).text('저장'); // 텍스트를 '저장'으로 변경
+        } else {
+            isEditing = false;
+            $(this).text('편집'); // 텍스트를 '편집'으로 변경
         }
+
+        // 그리드를 다시 렌더링해서 editor 상태를 반영
+        projectMemberGrid.repaint();
     });
 
-
+    initGrid();  // 공통 코드 로드 및 그리드 초기화
+    loadTeamData(projectNo);
+    loadProjectMembers(projectNo);
+    $(".team-overview, .team-members").hide();
+    $("#project-member-grid-section").show();
 });
 
 function openGroupPopup() {
@@ -141,13 +141,27 @@ function renderTeamTree(treeData) {
                 return false;
             },
             dragDrop: function (node, data) {
-                data.otherNode.moveTo(node, data.hitMode);
+                if (data.hitMode === "before" || data.hitMode === "after" || data.hitMode === "over") {
+                    data.otherNode.moveTo(node, data.hitMode);
+                }
             }
         },
         activate: function(event, data) {
             var node = data.node;
             var teamKey = node.key;
             var teamName = node.title;
+
+            if(node.data.parentId === null){
+                $(".team-overview, .team-members, .member-detail").hide();
+                $("#project-member-grid-section").show();
+                loadProjectMembers(projectNo);
+            } else {
+                $(".team-overview, .team-members").show();
+                $("#project-member-grid-section").hide();
+                $(".member-detail").hide();
+                updateTeamInfo(node.data, teamName);
+                loadTeamMembers(teamKey);
+            }
 
             updateTeamInfo(node.data, teamName);
             loadTeamMembers(teamKey);
@@ -172,7 +186,9 @@ function toggleEditMode() {
                 return true;
             },
             dragDrop: function (node, data) {
-                data.otherNode.moveTo(node, data.hitMode);
+                if (data.hitMode === "before" || data.hitMode === "after" || data.hitMode === "over") {
+                    data.otherNode.moveTo(node, data.hitMode);
+                }
             }
         });
     } else {
@@ -200,7 +216,7 @@ function loadTeamMembers(teamKey) {
     console.log("선택한 팀의 key: " + teamKey);
 
     $.ajax({
-        url: 'http://localhost:8085/members',
+        url: 'http://localhost:8085/projects/members/team',
         method: 'GET',
         data: {teamNo: teamKey},
         dataType: 'json',
@@ -218,16 +234,33 @@ function loadTeamMembers(teamKey) {
 $(document).on("click", ".member-link", function(e) {
     e.preventDefault();
     var memberId = $(this).data("id");
-
     var memberData = teamMemberGrid.list.find(item => item.id === memberId);
 
     if (memberData) {
         updateMemberDetail(memberData);
+    } else {
+        loadMemberDetails(memberId);
     }
+
+    document.querySelector(".member-detail").scrollIntoView({ behavior: 'smooth' });
 });
 
+function loadMemberDetails(memberNo) {
+    $.ajax({
+        url: '/projects/members/detail',
+        method: 'GET',
+        data: { memberNo: memberNo },
+        dataType: 'json',
+        success: function(response) {
+            updateMemberDetail(response);
+        },
+        error: function(error) {
+            console.error("인력 상세 정보 불러오기 실패:", error);
+        }
+    });
+}
+
 function updateMemberDetail(memberData) {
-    // 성명, 프로젝트 권한, 직위, 기술등급, 이메일, 전화번호 정보 업데이트
     $("#member-name").text(memberData.memberName || '-');
     $("#project-auth").text(memberData.auth || '-');
     $("#tech-grade").text(memberData.tech || '-');
@@ -259,3 +292,250 @@ function updateMemberDetail(memberData) {
 }
 
 
+// 프로젝트 팀원 목록을 불러오는 함수
+function loadProjectMembers(projectNo) {
+    $.ajax({
+        url: 'http://localhost:8085/projects/projectmembers',
+        method: 'GET',
+        data: { projectNo: projectNo },
+        dataType: 'json',
+        success: function (response) {
+            console.log("프로젝트 팀원 목록 데이터:", response);
+            projectMemberGrid.setData(response);
+
+        },
+        error: function (error) {
+            console.error("프로젝트 팀원 목록 불러오기 실패:", error);
+        }
+    });
+}
+//프로젝트 권환 공통 코드 가져오기
+function loadAuthCommonCode() {
+    return new Promise(function(resolve, reject) {
+        $.ajax({
+            url: '/getCommonCodeList',
+            type: 'GET',
+            data: {
+                commonCodeNo: 'PMS002'
+            },
+            success: function(response) {
+                var options = response.map(function(item) {
+                    return {
+                        CD: item.codeDetailNo,
+                        NM: item.codeDetailName
+                    };
+                });
+                resolve(options);
+            },
+            error: function(xhr, status, error) {
+                console.error("공통 코드 로드 오류: ", error);
+                reject(error);
+            }
+        });
+    });
+}
+
+function initGrid() {
+    // 공통 코드 가져오기
+    loadAuthCommonCode().then(function(commonCodeOptions) {
+        // teamMemberGrid 설정
+        teamMemberGrid = new ax5.ui.grid();
+        teamMemberGrid.setConfig({
+            showRowSelector: true,
+            target: $('[data-ax5grid="teamMemberGrid"]'),
+            columns: [
+                {key: "memberName", label: "성명", align: "center", formatter: function() {
+                        return '<a href="#" class="clickable-name member-link" data-id="' + this.item.id + '">' + this.value + '</a>';
+                    }},
+                {
+                    key: "auth",
+                    label: "프로젝트 권환",
+                    align: "center",
+                    editor: {
+                        type: "select",
+                        config: {
+                            columnKeys: {
+                                optionValue: "CD",
+                                optionText: "NM"
+                            },
+                            options: commonCodeOptions
+                        },
+                        disabled: function () {
+                            return !isEditing;
+                        }
+                    },
+                    formatter: function() {
+                        var selectedOption = commonCodeOptions.find(function(option) {
+                            return option.CD === this.value;
+                        }.bind(this));
+                        return selectedOption ? selectedOption.NM : this.value;
+                    }
+                },
+                {key: "groupName", width: 110, label: "소속", align: "center"},
+                {key: "position", width: 80, label: "직위", align: "center"},
+                {key: "preStartDate", width: 120, label: "예정시작일", align: "center", editor: {
+                        type: "date",
+                        config: {
+                            content: {
+                                config: {
+                                    mode: "year", selectMode: "day"
+                                }
+                            }
+                        },
+                        disabled: function () {
+                            return !isEditing;
+                        }
+                    }, formatter: function() {
+                        return this.value ? this.value.substring(0, 10) : '';}},
+                {key: "preEndDate", width: 120, label: "예정종료일", align: "center", editor: {
+                        type: "date",
+                        config: {
+                            content: {
+                                config: {
+                                    mode: "year", selectMode: "day"
+                                }
+                            }
+                        },
+                        disabled: function () {
+                            return !isEditing;
+                        }
+                    }, formatter: function() {
+                        return this.value ? this.value.substring(0, 10) : '';}},
+                {key: "startDate", width: 120, label: "참여시작일", align: "center", editor: {
+                        type: "date",
+                        config: {
+                            content: {
+                                config: {
+                                    mode: "year", selectMode: "day"
+                                }
+                            }
+                        },
+                        disabled: function () {
+                            return !isEditing;
+                        }
+                    }, formatter: function() {
+                        return this.value ? this.value.substring(0, 10) : '';}},
+                {key: "endDate", width: 120, label: "참여종료일", align: "center", editor: {
+                        type: "date",
+                        config: {
+                            content: {
+                                config: {
+                                    mode: "year", selectMode: "day"
+                                }
+                            }
+                        },
+                        disabled: function () {
+                            return !isEditing;
+                        }
+                    }, formatter: function() {
+                        return this.value ? this.value.substring(0, 10) : '';}},
+                {key: "tech", width: 80, label: "기술등급", align: "center"}
+            ],
+            page: {
+                display: false
+            }
+        });
+
+        // projectMemberGrid 설정
+        console.log(commonCodeOptions);
+        projectMemberGrid = new ax5.ui.grid();
+        projectMemberGrid.setConfig({
+            showRowSelector: true,
+            target: $('[data-ax5grid="projectMemberGrid"]'),
+            columns: [
+                {key: "memberName", label: "성명", align: "center", formatter: function() {
+                        return '<a href="#" class="clickable-name member-link" data-id="' + this.item.id + '">' + this.value + '</a>';}},
+                {
+                    key: "auth",
+                    label: "프로젝트권한",
+                    align: "center",
+                    editor: {
+                        type: "select",
+                        config: {
+                            columnKeys: {
+                                optionValue: "CD",
+                                optionText: "NM"
+                            },
+                            options: commonCodeOptions
+                        },
+                        disabled: function () {
+                            return !isEditing;
+                        }
+                    },
+                    formatter: function() {
+                        var selectedOption = commonCodeOptions.find(function(option) {
+                            return option.CD === this.value;
+                        }.bind(this));
+                        return selectedOption ? selectedOption.NM : this.value;
+                    }
+                },
+                {key: "groupName", width: 90, label: "소속", align: "center"},
+                {key: "position", width: 80, label: "직위", align: "center"},
+                {key: "tech", width: 80, label: "기술등급", align: "center"},
+                {key: "teamName", width: 110, label: "소속팀", align: "center"},
+                {key: "preStartDate", width: 100, label: "예정시작일", align: "center", editor: {
+                        type: "date",
+                        config: {
+                            content: {
+                                config: {
+                                    mode: "year", selectMode: "day"
+                                }
+                            }
+                        },
+                        disabled: function () {
+                            return !isEditing;
+                        }
+                    }, formatter: function() {
+                        return this.value ? this.value.substring(0, 10) : '';}},
+                {key: "preEndDate", width: 100, label: "예정종료일", align: "center", editor: {
+                        type: "date",
+                        config: {
+                            content: {
+                                config: {
+                                    mode: "year", selectMode: "day"
+                                }
+                            }
+                        },
+                        disabled: function () {
+                            return !isEditing;
+                        }
+                    }, formatter: function() {
+                        return this.value ? this.value.substring(0, 10) : '';}},
+                {key: "startDate", width: 100, label: "참여시작일", align: "center", editor: {
+                        type: "date",
+                        config: {
+                            content: {
+                                config: {
+                                    mode: "year", selectMode: "day"
+                                }
+                            }
+                        },
+                        disabled: function () {
+                            return !isEditing;
+                        }
+                    }, formatter: function() {
+                        return this.value ? this.value.substring(0, 10) : '';}},
+                {key: "endDate", width: 100, label: "참여종료일", align: "center", editor: {
+                        type: "date",
+                        config: {
+                            content: {
+                                config: {
+                                    mode: "year", selectMode: "day"
+                                }
+                            }
+                        },
+                        disabled: function () {
+                            return !isEditing;
+                        }
+                    }, formatter: function() {
+                        return this.value ? this.value.substring(0, 10) : '';}}
+            ],
+            page: {
+                display: false
+            }
+        });
+
+    }).catch(function(error) {
+        console.error("그리드 초기화 오류: ", error);
+    });
+}

--- a/src/main/webapp/resources/member/js/memberRegister.js
+++ b/src/main/webapp/resources/member/js/memberRegister.js
@@ -43,6 +43,8 @@ $(document).ready(function() {
                 console.error('인원 목록을 가져오는 데 실패했습니다: ', error);
             }
         });
+
+        $('#memberList').children().show();
     });
 
     // 검색 기능
@@ -74,4 +76,6 @@ $(document).ready(function() {
         console.log(movedNodeId);
         console.log(newPosition);
     });
+
+    $('#memberList').children().hide();
 });

--- a/src/main/webapp/resources/member/js/memberRegisterGrid.js
+++ b/src/main/webapp/resources/member/js/memberRegisterGrid.js
@@ -4,42 +4,12 @@ var addedGrid;
 let isEditing = false;
 let addedMembers = [];
 $(document.body).ready(function () {
-    function updateAddedGrid() {
-        addedGrid.setData(addedMembers);
-    }
-    //프로젝트 권환 공통 코드 가져오기
-    function loadAuthCommonCode() {
-        return new Promise(function(resolve, reject) {
-            $.ajax({
-                url: '/getCommonCodeList',
-                type: 'GET',
-                data: {
-                    commonCodeNo: 'PMS002'
-                },
-                success: function(response) {
-                    var options = response.map(function(item) {
-                        return {
-                            CD: item.codeDetailNo,
-                            NM: item.codeDetailName
-                        };
-                    });
-                    resolve(options);
-                },
-                error: function(xhr, status, error) {
-                    console.error("공통 코드 로드 오류: ", error);
-                    reject(error);
-                }
-            });
-        });
-    }
-
     $('#project_member_total').on('click', function() {
         $('#add-member-by-prjmem').show();
         $('#add-member-by-group').hide();
 
         let $table =  $('#add-member-by-group').find('#y-added-grid');
         $('#grid-parent2').append($table);
-        //updateAddedGrid();
     });
 
     $('#group_total').on('click', function() {
@@ -48,7 +18,6 @@ $(document.body).ready(function () {
 
         let $table =  $('#grid-parent2').find('#y-added-grid');
         $('#grid-parent3').append($table);
-        // updateAddedGrid();
     });
 
 
@@ -99,12 +68,12 @@ $(document.body).ready(function () {
                     name: member.memberName,
                     auth: member.auth ? member.auth : "",
                     group: member.groupName,
-                    position: member.positionName,
-                    pre_st_dt: "",
-                    pre_end_dt: "",
-                    st_dt: "",
-                    end_dt: "",
-                    techGrade: member.techGrade
+                    position: member.position,
+                    pre_st_dt: member.preStartDate ? member.preStartDate : "",
+                    pre_end_dt: member.preEndDate ? member.preEndDate : "",
+                    st_dt: member.startDate ? member.startDate : "",
+                    end_dt: member.endDate ? member.endDate : "",
+                    techGrade: member.tech
                 });
             }
         });
@@ -113,170 +82,16 @@ $(document.body).ready(function () {
     });
 
 
-    groupmemGrid = new ax5.ui.grid();
-
-    groupmemGrid.setConfig({
-        showRowSelector: true,
-        target: $('[data-ax5grid="groupmemGrid"]'),
-        columns: [
-            {key: "memberName", label: "성명", align: "center"},
-            {key: "positionName", label: "직위", align: "center" },
-            {key: "email", width: 220, label: "이메일", align: "center"},
-            {key: "participate_yn", width: 70, label: "참여여부",align: "center"},
-            {key: "techGrade", width: 70, label: "기술등급",align: "center"}
-        ],
-        page: {
-            display: false
-        }
-    });
-
-
-    function initGrid() {
-        loadAuthCommonCode().then(function(commonCodeOptions) {
-            addedGrid = new ax5.ui.grid();
-            addedGrid.setConfig({
-                showRowSelector: true,
-                target: $('[data-ax5grid="added-grid"]'),
-                columns: [
-                    {key: "name", label: "성명", align: "center"},
-                    {
-                        key: "auth",
-                        label: "프로젝트권한",
-                        align: "center",
-                        editor: {
-                            type: "select",
-                            config: {
-                                columnKeys: {
-                                    optionValue: "CD",
-                                    optionText: "NM"
-                                },
-                                options: commonCodeOptions
-                            },
-                            disabled: function () {
-                                return !isEditing;
-                            }
-                        },
-                        formatter: function() {
-                            var selectedOption = commonCodeOptions.find(function(option) {
-                                return option.CD === this.value;
-                            }.bind(this));
-                            return selectedOption ? selectedOption.NM : this.value;
-                        }
-                    },
-                    {key: "group", width: 100, label: "소속", align: "center"},
-                    {key: "position", width: 70, label: "직위", align: "center"},
-                    {key: "pre_st_dt", width: 100, label: "예정시작일", align: "center", editor: {
-                            type: "date",
-                            config: {
-                                content: {
-                                    config: {
-                                        mode: "year", selectMode: "day"
-                                    }
-                                }
-                            },
-                            disabled: function () {
-                                return !isEditing;
-                            }
-                        }
-                    },
-                    {key: "pre_end_dt", width: 100, label: "예정종료일", align: "center", editor: {
-                            type: "date",
-                            config: {
-                                content: {
-                                    config: {
-                                        mode: "year", selectMode: "day"
-                                    }
-                                }
-                            },
-                            disabled: function () {
-                                return !isEditing;
-                            }
-                        }
-                    },
-                    {key: "st_dt", width: 100, label: "참여시작일", align: "center", editor: {
-                            type: "date",
-                            config: {
-                                content: {
-                                    config: {
-                                        mode: "year", selectMode: "day"
-                                    }
-                                }
-                            },
-                            disabled: function () {
-                                return !isEditing;
-                            }
-                        }
-                    },
-                    {key: "end_dt", width: 100, label: "참여종료일", align: "center", editor: {
-                            type: "date",
-                            config: {
-                                content: {
-                                    config: {
-                                        mode: "year", selectMode: "day"
-                                    }
-                                }
-                            },
-                            disabled: function () {
-                                return !isEditing;
-                            }
-                        }
-                    },
-                    {key: "techGrade", width: 70, label: "기술등급", align: "center"}
-                ],
-                page: {
-                    display: false
-                }
-            });
-        }).catch(function(error) {
-            console.error("그리드 초기화 오류: ", error);
-        });
-    }
-
-    initGrid();
-
-    prjmemGrid = new ax5.ui.grid();
-    prjmemGrid.setConfig({
-        showRowSelector: true,
-        target: $('[data-ax5grid="prjmember-grid"]'),
-        columns: [
-            {key: "name", label: "성명", align: "center"},
-            {key: "auth", label: "프로젝트권환", align: "center"},
-            {key: "group", width: 100, label: "소속", align: "center"},
-            {key: "position", width: 70, label: "직위",align: "center"},
-            {key: "pre_st_dt", width: 100, label: "예정시작일",align: "center"},
-            {key: "pre_end_dt", width: 100, label: "예정종료일",align: "center"},
-            {key: "st_dt", width: 100, label: "참여시작일",align: "center"},
-            {key: "end_dt", width: 100, label: "참여종료일",align: "center"},
-            {key: "tech_grd", width: 70, label: "기술등급",align: "center"}
-        ],
-        page: {
-            display: false
-        }
-    });
-
-    prjmemGrid.setData([
-        {id: 101, name: "김연호", auth: "PM", group: "SI 1팀", position: "차장", pre_st_dt: "2024-05-12", pre_end_dt: "2025-05-12", tech_grd: "고급"},
-        {id: 102, name: "이수호", auth: "PL", group: "SI 1팀", position: "차장", pre_st_dt: "2024-05-12", pre_end_dt: "2025-05-12", tech_grd: "고급"},
-        {id: 103, name: "이한희", auth: "PL", group: "SI 1팀", position: "차장", pre_st_dt: "2024-05-12", pre_end_dt: "2025-05-12", tech_grd: "고급"},
-        {id: 104, name: "홍길동", auth: "팀원", group: "SI 1팀", position: "차장", pre_st_dt: "2024-05-12", pre_end_dt: "2025-05-12", tech_grd: "고급"},
-        {id: 105, name: "김연호", auth: "PM", group: "SI 1팀", position: "차장", pre_st_dt: "2024-05-12", pre_end_dt: "2025-05-12", tech_grd: "고급"},
-        {id: 106, name: "이수호", auth: "PL", group: "SI 1팀", position: "차장", pre_st_dt: "2024-05-12", pre_end_dt: "2025-05-12", tech_grd: "고급"},
-        {id: 107, name: "이한희", auth: "PL", group: "SI 1팀", position: "차장", pre_st_dt: "2024-05-12", pre_end_dt: "2025-05-12", tech_grd: "고급"},
-        {id: 108, name: "홍길동", auth: "팀원", group: "SI 1팀", position: "차장", pre_st_dt: "2024-05-12", pre_end_dt: "2025-05-12", tech_grd: "고급"},
-        {id: 109, name: "김연호", auth: "PM", group: "SI 1팀", position: "차장", pre_st_dt: "2024-05-12", pre_end_dt: "2025-05-12", tech_grd: "고급"},
-        {id: 110, name: "이수호", auth: "PL", group: "SI 1팀", position: "차장", pre_st_dt: "2024-05-12", pre_end_dt: "2025-05-12", tech_grd: "고급"},
-        {id: 111, name: "이한희", auth: "PL", group: "SI 1팀", position: "차장", pre_st_dt: "2024-05-12", pre_end_dt: "2025-05-12", tech_grd: "고급"},
-        {id: 112, name: "홍길동", auth: "팀원", group: "SI 1팀", position: "차장", pre_st_dt: "2024-05-12", pre_end_dt: "2025-05-12", tech_grd: "고급"}
-    ]);
-
-    $('#add-member-by-prjmem').hide();
-
 
     // 적용 버튼 클릭
     $('#apply').on('click', function() {
         insertProject();
     });
 
+    initGrid();
+    loadProjectMember();
+
+    $('#add-member-by-prjmem').hide();
 });
 
 checkProject();
@@ -304,4 +119,202 @@ function insertProject() {
             console.log("부모 창을 인식하지 못했습니다.");
         }
     }
+}
+
+
+function updateAddedGrid() {
+    addedGrid.setData(addedMembers);
+}
+
+function loadProjectMember() {
+    //프로젝트 총인원
+    $.ajax({
+        url: '/projects/projectmembers',
+        method: 'GET',
+        data: {
+            projectNo: 1
+        },
+        success: function(response) {
+            prjmemGrid.setData(response);
+        },
+        error: function(error) {
+            console.error("팀원 목록 불러오기 실패:", error);
+        }
+    });
+}
+//프로젝트 권환 공통 코드 가져오기
+function loadAuthCommonCode() {
+    return new Promise(function(resolve, reject) {
+        $.ajax({
+            url: '/getCommonCodeList',
+            type: 'GET',
+            data: {
+                commonCodeNo: 'PMS002'
+            },
+            success: function(response) {
+                var options = response.map(function(item) {
+                    return {
+                        CD: item.codeDetailNo,
+                        NM: item.codeDetailName
+                    };
+                });
+                resolve(options);
+            },
+            error: function(xhr, status, error) {
+                console.error("공통 코드 로드 오류: ", error);
+                reject(error);
+            }
+        });
+    });
+}
+
+
+function initGrid() {
+    groupmemGrid = new ax5.ui.grid();
+    groupmemGrid.setConfig({
+        showRowSelector: true,
+        target: $('[data-ax5grid="groupmemGrid"]'),
+        columns: [
+            {key: "memberName", label: "성명", align: "center"},
+            {key: "position", label: "직위", align: "center" },
+            {key: "email", width: 220, label: "이메일", align: "center"},
+            {key: "participate_yn", width: 70, label: "참여여부",align: "center"},
+            {key: "tech", width: 70, label: "기술등급",align: "center"}
+        ],
+        page: {
+            display: false
+        }
+    });
+
+
+    prjmemGrid = new ax5.ui.grid();
+    prjmemGrid.setConfig({
+        showRowSelector: true,
+        target: $('[data-ax5grid="prjmember-grid"]'),
+        columns: [
+            {key: "memberName", label: "성명", align: "center"},
+            {key: "auth", label: "프로젝트권환", align: "center"},
+            {key: "groupName", width: 100, label: "소속", align: "center"},
+            {key: "position", width: 70, label: "직위",align: "center"},
+            {key: "preStartDate", width: 100, label: "예정시작일",align: "center",formatter: function() {
+                    return this.value ? this.value.substring(0, 10) : '';}},
+            {key: "preEndDate", width: 100, label: "예정종료일",align: "center",formatter: function() {
+                    return this.value ? this.value.substring(0, 10) : '';}},
+            {key: "startDate", width: 100, label: "참여시작일",align: "center",formatter: function() {
+                    return this.value ? this.value.substring(0, 10) : '';}},
+            {key: "endDate", width: 100, label: "참여종료일",align: "center",formatter: function() {
+                    return this.value ? this.value.substring(0, 10) : '';}},
+            {key: "tech", width: 70, label: "기술등급",align: "center"}
+        ],
+        page: {
+            display: false
+        }
+    });
+
+    loadAuthCommonCode().then(function(commonCodeOptions) {
+        addedGrid = new ax5.ui.grid();
+        addedGrid.setConfig({
+            showRowSelector: true,
+            target: $('[data-ax5grid="added-grid"]'),
+            columns: [
+                {key: "name", label: "성명", align: "center"},
+                {
+                    key: "auth",
+                    label: "프로젝트권한",
+                    align: "center",
+                    editor: {
+                        type: "select",
+                        config: {
+                            columnKeys: {
+                                optionValue: "CD",
+                                optionText: "NM"
+                            },
+                            options: commonCodeOptions
+                        },
+                        disabled: function () {
+                            return !isEditing;
+                        }
+                    },
+                    formatter: function() {
+                        var selectedOption = commonCodeOptions.find(function(option) {
+                            return option.CD === this.value;
+                        }.bind(this));
+                        return selectedOption ? selectedOption.NM : this.value;
+                    }
+                },
+                {key: "group", width: 100, label: "소속", align: "center"},
+                {key: "position", width: 70, label: "직위", align: "center"},
+                {key: "pre_st_dt", width: 100, label: "예정시작일", align: "center", editor: {
+                        type: "date",
+                        config: {
+                            content: {
+                                config: {
+                                    mode: "year", selectMode: "day"
+                                }
+                            }
+                        },
+                        disabled: function () {
+                            return !isEditing;
+                        }
+                    },
+                    formatter: function() {
+                        return this.value ? this.value.substring(0, 10) : '';}
+                },
+                {key: "pre_end_dt", width: 100, label: "예정종료일", align: "center", editor: {
+                        type: "date",
+                        config: {
+                            content: {
+                                config: {
+                                    mode: "year", selectMode: "day"
+                                }
+                            }
+                        },
+                        disabled: function () {
+                            return !isEditing;
+                        }
+                    },
+                    formatter: function() {
+                        return this.value ? this.value.substring(0, 10) : '';}
+                },
+                {key: "st_dt", width: 100, label: "참여시작일", align: "center", editor: {
+                        type: "date",
+                        config: {
+                            content: {
+                                config: {
+                                    mode: "year", selectMode: "day"
+                                }
+                            }
+                        },
+                        disabled: function () {
+                            return !isEditing;
+                        },
+                        formatter: function() {
+                            return this.value ? this.value.substring(0, 10) : '';}
+                    }
+                },
+                {key: "end_dt", width: 100, label: "참여종료일", align: "center", editor: {
+                        type: "date",
+                        config: {
+                            content: {
+                                config: {
+                                    mode: "year", selectMode: "day"
+                                }
+                            }
+                        },
+                        disabled: function () {
+                            return !isEditing;
+                        },
+                        formatter: function() {
+                            return this.value ? this.value.substring(0, 10) : '';}
+                    }
+                },
+                {key: "techGrade", width: 70, label: "기술등급", align: "center"}
+            ],
+            page: {
+                display: false
+            }
+        });
+    }).catch(function(error) {
+        console.error("그리드 초기화 오류: ", error);
+    });
 }


### PR DESCRIPTION
# 작업 내용
- 프로젝트 총 인원 목록 조회
- 인력 등록 팝업 페이지에서 목록 찾기 시 총 인원 조회
- 팀 트리 구조에서 팀 인원 수 구하는 SQL 수정
- ax5ui grid 날짜 포맷 지정
- 모든 grid는 편집 버튼을 누른 후 값 수정이 가능 

# To Reviewers
- 팀에 속한 사원 목록을 가져오는 로직이 team 도메인에서 member 도메인으로 변경되었습니다.
- 추후 리팩토링 과정에서 팀에 속한 사원 목록을 가져오는 로직은 없어질 수 있습니다. (페이지 렌더링 시 프로젝트 총 인원을 가져오므로)
# Screen Shot (선택)

# Issue
- resolved: #56 
