### PR TITLE
[#63] 팀 트리 구조 순서 변경 서버 로직 구현

### DIFF
--- a/src/main/java/com/kcc/pms/domain/team/controller/TeamController.java
+++ b/src/main/java/com/kcc/pms/domain/team/controller/TeamController.java
@@ -1,12 +1,11 @@
 package com.kcc.pms.domain.team.controller;
 
+import com.kcc.pms.domain.team.model.dto.TeamOrderUpdateRequestDto;
 import com.kcc.pms.domain.team.model.dto.TeamResponseDto;
 import com.kcc.pms.domain.team.service.TeamService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -19,6 +18,12 @@ public class TeamController {
     @ResponseBody
     public List<TeamResponseDto> getTeamList(@RequestParam("projectNo") Long projectNo) {
         return teamService.getTeamList(projectNo);
+    }
+
+    @PostMapping("/teams/updateOrder")
+    @ResponseBody
+    public void updateOrder(@RequestBody TeamOrderUpdateRequestDto request){
+        teamService.updateOrder(request.getTeamNo(), request.getNewParentNo(), request.getNewPosition() + 1);
     }
 
 }

--- a/src/main/java/com/kcc/pms/domain/team/mapper/TeamMapper.java
+++ b/src/main/java/com/kcc/pms/domain/team/mapper/TeamMapper.java
@@ -1,11 +1,16 @@
 package com.kcc.pms.domain.team.mapper;
 
 import com.kcc.pms.domain.team.model.dto.TeamResponseDto;
+import com.kcc.pms.domain.team.model.vo.Team;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
 
 @Mapper
 public interface TeamMapper {
     List<TeamResponseDto> getTeamList(Long projectNo);
+    Team getTeamByNo(Integer teamNo);
+    List<Team> getSiblings(Integer parentNo);
+    void updateTeamOrder(@Param("teamNo") Integer teamNo, @Param("parentNo") Integer parentNo, @Param("orderNo") Integer orderNo);
 }

--- a/src/main/java/com/kcc/pms/domain/team/model/dto/TeamOrderUpdateRequestDto.java
+++ b/src/main/java/com/kcc/pms/domain/team/model/dto/TeamOrderUpdateRequestDto.java
@@ -1,0 +1,12 @@
+package com.kcc.pms.domain.team.model.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TeamOrderUpdateRequestDto {
+    private Integer teamNo;
+    private Integer newParentNo;
+    private Integer newPosition;
+}

--- a/src/main/java/com/kcc/pms/domain/team/model/vo/Team.java
+++ b/src/main/java/com/kcc/pms/domain/team/model/vo/Team.java
@@ -8,6 +8,8 @@ import java.io.Serializable;
 @Getter
 @Setter
 public class Team implements Serializable {
-    private Long teamNo;
+    private Integer teamNo;
+    private Integer parentNo;
     private String teamName;
+    private int orderNo;
 }

--- a/src/main/java/com/kcc/pms/domain/team/service/TeamService.java
+++ b/src/main/java/com/kcc/pms/domain/team/service/TeamService.java
@@ -6,4 +6,5 @@ import java.util.List;
 
 public interface TeamService {
     List<TeamResponseDto> getTeamList(Long projectNo);
+    void updateOrder(Integer teamNo, Integer newParentNo, Integer newPosition);
 }

--- a/src/main/java/com/kcc/pms/domain/team/service/TeamServiceImpl.java
+++ b/src/main/java/com/kcc/pms/domain/team/service/TeamServiceImpl.java
@@ -2,6 +2,7 @@ package com.kcc.pms.domain.team.service;
 
 import com.kcc.pms.domain.team.mapper.TeamMapper;
 import com.kcc.pms.domain.team.model.dto.TeamResponseDto;
+import com.kcc.pms.domain.team.model.vo.Team;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -15,6 +16,60 @@ public class TeamServiceImpl implements TeamService{
     @Override
     public List<TeamResponseDto> getTeamList(Long projectNo) {
         return buildTree(mapper.getTeamList(projectNo));
+    }
+
+    @Override
+    public void updateOrder(Integer teamNo, Integer newParentNo, Integer newPosition) {
+        System.out.println("teamNo = " + teamNo);
+        System.out.println("newParentNo = " + newParentNo);
+        System.out.println("newPosition = " + newPosition);
+
+        Team movedTeam = mapper.getTeamByNo(teamNo);
+        Integer oldParentId = movedTeam.getParentNo();
+
+        List<Team> oldSiblings = mapper.getSiblings(oldParentId);
+
+
+        List<Team> newSiblings = mapper.getSiblings(newParentNo);
+
+        //부모가 동일한 경우 (같은 부모 하위에서 순서만 변경된 경우)
+        if (oldParentId.equals(newParentNo)) {
+            for (Team sibling : oldSiblings) {
+                if (!sibling.getTeamNo().equals(teamNo)) {
+                    if (movedTeam.getOrderNo() < newPosition && sibling.getOrderNo() > movedTeam.getOrderNo() && sibling.getOrderNo() <= newPosition) {
+                        sibling.setOrderNo(sibling.getOrderNo() - 1);  // 한 칸씩 당김
+                        mapper.updateTeamOrder(sibling.getTeamNo(), null, sibling.getOrderNo());
+                    } else if (movedTeam.getOrderNo() > newPosition && sibling.getOrderNo() < movedTeam.getOrderNo() && sibling.getOrderNo() >= newPosition) {
+                        sibling.setOrderNo(sibling.getOrderNo() + 1);  // 한 칸씩 밀어냄
+                        mapper.updateTeamOrder(sibling.getTeamNo(), null, sibling.getOrderNo());
+                    }
+                }
+            }
+        }
+        //부모가 다른 경우 (부모가 변경된 경우)
+        else {
+            // 기존 부모의 형제들의 순서 변경
+            for (Team sibling : oldSiblings) {
+                if (sibling.getOrderNo() > movedTeam.getOrderNo()) {
+                    sibling.setOrderNo(sibling.getOrderNo() - 1);
+                    mapper.updateTeamOrder(sibling.getTeamNo(), null, sibling.getOrderNo());
+                }
+            }
+
+            // 새로운 부모의 형제들의 순서 변경
+            for (Team sibling : newSiblings) {
+                if (sibling.getOrderNo() >= newPosition) {
+                    sibling.setOrderNo(sibling.getOrderNo() + 1);
+                    mapper.updateTeamOrder(sibling.getTeamNo(), null, sibling.getOrderNo());
+                }
+            }
+
+            movedTeam.setParentNo(newParentNo);
+        }
+
+        movedTeam.setOrderNo(newPosition);
+
+        mapper.updateTeamOrder(movedTeam.getTeamNo(), newParentNo, newPosition);
     }
 
 

--- a/src/main/resources/mapper/MemberMapper.xml
+++ b/src/main/resources/mapper/MemberMapper.xml
@@ -76,6 +76,7 @@
     <resultMap id="connectTeams" type="com.kcc.pms.domain.team.model.vo.Team">
         <result column="TM_NO" property="teamNo" />
         <result column="TM_NM" property="teamName" />
+        <result column="ORDER_NO" property="orderNo"/>
     </resultMap>
 
 
@@ -93,7 +94,8 @@
                m.phone_no,
                tech.cd_dtl_nm AS TECH,
                t.tm_no,
-               t.tm_nm
+               t.tm_nm,
+               t.order_no
         FROM projectmember pm,
              member m,
              usergroup g,
@@ -126,14 +128,15 @@
                m.email,
                m.phone_no,
                pmt.tm_no,
-               pmt.tm_nm
+               pmt.tm_nm,
+               pmt.order_no
         FROM projectmember pm,
              member m,
              usergroup gr,
              codedetail auth,
              codedetail pos,
              codedetail tech,
-             (SELECT t.tm_no, t.tm_nm, pm.mem_no
+             (SELECT t.tm_no, t.tm_nm, pm.mem_no, t.order_no
               FROM team t, projectmember pm
               WHERE t.tm_no = pm.tm_no
                 AND t.par_tm_no IS NOT NULL

--- a/src/main/resources/mapper/TeamMapper.xml
+++ b/src/main/resources/mapper/TeamMapper.xml
@@ -45,4 +45,32 @@
         ORDER BY NVL(t.par_tm_no, t.tm_no), t.order_no
     </select>
 
+    <select id="getTeamByNo" resultType="com.kcc.pms.domain.team.model.vo.Team">
+        SELECT tm_no AS teamNo,
+               tm_nm AS teamName,
+               par_tm_no AS parentNo,
+               order_no AS orderNo
+        FROM team
+        WHERE tm_no = #{teamNo}
+    </select>
+
+    
+    <select id="getSiblings" resultType="com.kcc.pms.domain.team.model.vo.Team">
+        SELECT tm_no AS teamNo,
+               tm_nm AS teamName,
+               par_tm_no AS parentNo,
+               order_no AS orderNo
+        FROM team
+        WHERE par_tm_no = #{parentNo}
+        ORDER BY order_no ASC
+    </select>
+
+    <update id="updateTeamOrder">
+        UPDATE team
+        SET order_no = #{orderNo}
+        <if test="parentNo != null">
+            , par_tm_no = #{parentNo}
+        </if>
+        WHERE tm_no = #{teamNo}
+    </update>
 </mapper>

--- a/src/main/webapp/resources/member/js/list.js
+++ b/src/main/webapp/resources/member/js/list.js
@@ -186,9 +186,15 @@ function toggleEditMode() {
                 return true;
             },
             dragDrop: function (node, data) {
+                if ((!node.parent || node.isTopLevel())) {
+                    console.log("최상위 노드 위에 드롭 불가");
+                    return false;
+                }
+
                 if (data.hitMode === "before" || data.hitMode === "after" || data.hitMode === "over") {
                     data.otherNode.moveTo(node, data.hitMode);
                 }
+                updateNodeOrder(data.otherNode, data.node, data.hitMode);
             }
         });
     } else {
@@ -196,6 +202,36 @@ function toggleEditMode() {
         $(".fancytree-container").fancytree("option", "dnd5", null);
         alert("순서가 저장되었습니다");
     }
+}
+
+//팀 순서 업데이트
+function updateNodeOrder(movedNode, targetNode, hitMode) {
+    const movedNodeId = movedNode.key;
+    let newParentId;
+    const newPosition = movedNode.getIndex();
+
+    if (hitMode === 'over') {
+        newParentId = targetNode.key;
+    } else {
+        newParentId = targetNode.parent ? targetNode.parent.key : null;
+    }
+
+    $.ajax({
+        url: '/teams/updateOrder',
+        type: 'POST',
+        contentType: 'application/json',
+        data: JSON.stringify({
+            teamNo: movedNodeId,
+            newParentNo: newParentId,
+            newPosition: newPosition
+        }),
+        success: function(response) {
+            console.log('노드 순서가 성공적으로 반영되었습니다.');
+        },
+        error: function(xhr, status, error) {
+            console.error('노드 순서 변경에 실패했습니다: ', error);
+        }
+    });
 }
 
 


### PR DESCRIPTION
# 작업 내용
- 팀 트리 구조 순서 변경 서버 로직 구현
- 순서를 변경하면 그 구조가 유지됩니다.
- 같은 부모 내에서의 이동, 다른 부모로의 이동 모두 가능합니다

# To Reviewers

# Screen Shot (선택)

# Issue
- resolved: #63 
