### PR TITLE
[#noissue] db 호스트명 조정

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,7 +45,7 @@ spring:
     activate:
       on-profile: dev
   datasource:
-    url: jdbc:oracle:thin:@localhost:${db.port}/xe
+    url: jdbc:oracle:thin:@${db.host}:${db.port}/xe
 #    url: jdbc:log4jdbc:oracle:thin:@localhost:${db.port}:xe
     username: ${db.username}
     password: ${db.password}


### PR DESCRIPTION
# 작업 내용
- 유연한 운영 환경 구성을 위해 db 호스트명을 분리 했습니다.

# To Reviewers

# Screen Shot (선택)
    url: jdbc:oracle:thin:@${db.host}:${db.port}/xe

# Issue
- #
