### PR TITLE
[#258] 투입인력 기능 보완

### DIFF
--- a/src/main/java/com/kcc/pms/domain/member/controller/MemberController.java
+++ b/src/main/java/com/kcc/pms/domain/member/controller/MemberController.java
@@ -1,16 +1,16 @@
 package com.kcc.pms.domain.member.controller;
 
-import com.kcc.pms.domain.member.model.dto.GroupMembersResponseDto;
-import com.kcc.pms.domain.member.model.dto.GroupResponseDto;
-import com.kcc.pms.domain.member.model.dto.ProjectMemberResponseDto;
+import com.kcc.pms.domain.member.model.dto.*;
 import com.kcc.pms.domain.member.service.MemberService;
-import com.kcc.pms.domain.member.model.dto.MemberResponseDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
+import java.sql.SQLException;
+import java.sql.SQLIntegrityConstraintViolationException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -51,43 +51,72 @@ public class MemberController {
 
     @GetMapping("/{projectNo}/members/team/{teamNo}")
     @ResponseBody
-    public List<MemberResponseDto> teamMembers(@PathVariable("projectNo") Long projectNo, @PathVariable("teamNo") Long teamNo) {
+    public List<MemberResponseTCDto> teamMembers(@PathVariable("projectNo") Long projectNo, @PathVariable("teamNo") Long teamNo) {
         return memberService.getTeamMember(teamNo);
     }
 
     @GetMapping("/projectmembers")
     @ResponseBody
     public List<MemberResponseDto> projectMembers(@RequestParam Long projectNo) {
+        List<MemberResponseDto> projectMemberList = memberService.getProjectMemberList(projectNo);
+        System.out.println(projectMemberList);
         return memberService.getProjectMemberList(projectNo);
     }
 
     @GetMapping("/{projectNo}/members/{memberNo}")
     @ResponseBody
-    public ResponseEntity<MemberResponseDto> memberDetail(@PathVariable("projectNo") Long projectNo, @PathVariable("memberNo") Long memberNo) {
+    public ResponseEntity<MemberResponseTCDto> memberDetail(@PathVariable("projectNo") Long projectNo, @PathVariable("memberNo") Long memberNo) {
         System.out.println("MemberController.memberDetail");
         System.out.println("projectNo = " + projectNo);
         System.out.println("memberNo = " + memberNo);
-        MemberResponseDto memberDetail = memberService.getMemberDetail(projectNo, memberNo);
+        MemberResponseTCDto memberDetail = memberService.getMemberDetail(projectNo, memberNo);
         System.out.println("memberDetail = " + memberDetail);
         return ResponseEntity.ok(memberDetail);
     }
 
-    @PatchMapping("/members/{memberNo}/team/{teamNo}")
+    @PostMapping("/members/team/{teamNo}")
     @ResponseBody
-    public ResponseEntity<String> memberAssignTeam(@PathVariable Long memberNo, @PathVariable Long teamNo, @RequestBody Map<String, Object> payload) {
-        Integer beforeTeamNo = (Integer) payload.get("beforeTeamNo");
-        System.out.println("beforeTeamNo = " + beforeTeamNo);
-        System.out.println("memberNo = " + memberNo);
+    public ResponseEntity<String> memberAssignTeam(@PathVariable Long teamNo, @RequestBody List<MemberTeamUpdateRequest> members) {
+        System.out.println("MemberController.memberAssignTeam");
         System.out.println("teamNo = " + teamNo);
-        try{
-            Integer result = memberService.memberAssignTeam(memberNo, teamNo, beforeTeamNo);
-            if(result != null) {
-                return ResponseEntity.ok("success assigning team");
-            } else {
-                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("fail assigning team");
+        System.out.println("members = " + members);
+        try {
+            for (MemberTeamUpdateRequest member : members) {
+                memberService.memberAssignTeam(member.getMemberId(), teamNo, member.getBeforeTeamNo());
             }
-        } catch (Exception e){
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("error: " + e.getMessage());
+            return ResponseEntity.ok("팀 배정에 성공하였습니다.");
+        } catch (DataIntegrityViolationException e) {
+            System.err.println("무결성 제약 조건 위반: " + e.getMessage());
+            return ResponseEntity.status(HttpStatus.CONFLICT).body("해당 팀에 이미 배정된 인원이 있습니다.");
+        } catch (Exception e) {
+            System.err.println("예상치 못한 오류: " + e.getMessage());
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("팀 배정 중 예상치 못한 오류가 발생했습니다.");
+        }
+    }
+
+    @PostMapping("/members/date")
+    public ResponseEntity<?> updateOrInsertDate(@RequestParam String type,
+                                                    @RequestBody List<MemberStartFinishRequestDto> memberList) {
+        System.out.println("MemberController.updateOrInsertDate");
+        System.out.println("memberList = " + memberList);
+        System.out.println("type = " + type);
+        try {
+            memberService.updateOrInsertDate(type, memberList);
+            return ResponseEntity.ok(type + " dates processed successfully");
+        } catch (SQLException e) {
+            System.out.println(e.getMessage());
+            return ResponseEntity.status(500).body("Error processing " + type + " dates: " + e.getMessage());
+        }
+    }
+
+    @PostMapping("/members")
+    public ResponseEntity<?> updateMembers(@RequestBody List<MemberUpdateRequestDto> members) {
+        System.out.println("members = " + members);
+        try {
+            memberService.updateMembers(members);
+            return ResponseEntity.ok("변경 사항이 성공적으로 저장되었습니다.");
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("업데이트 중 오류 발생: " + e.getMessage());
         }
     }
 }

--- a/src/main/java/com/kcc/pms/domain/member/mapper/MemberMapper.java
+++ b/src/main/java/com/kcc/pms/domain/member/mapper/MemberMapper.java
@@ -1,12 +1,11 @@
 package com.kcc.pms.domain.member.mapper;
 
-import com.kcc.pms.domain.member.model.dto.GroupMembersResponseDto;
-import com.kcc.pms.domain.member.model.dto.GroupResponseDto;
-import com.kcc.pms.domain.member.model.dto.MemberResponseDto;
+import com.kcc.pms.domain.member.model.dto.*;
 import com.kcc.pms.domain.member.model.vo.MemberVO;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
+import java.sql.SQLException;
 import java.util.List;
 
 @Mapper
@@ -14,9 +13,17 @@ public interface MemberMapper {
     List<GroupResponseDto> getGroupList();
     List<GroupMembersResponseDto> getGroupMemberList(Long groupNo);
     List<MemberResponseDto> getProjectMemberList(Long projectNo);
-    List<MemberResponseDto> getTeamMember(@Param("teamNo") Long teamNo);
-    MemberResponseDto getMemberDetail( @Param("projectNo") Long projectNo, @Param("memberNo") Long memberNo);
+    List<MemberResponseTCDto> getTeamMember(@Param("teamNo") Long teamNo);
+    MemberResponseTCDto getMemberDetail(@Param("projectNo") Long projectNo, @Param("memberNo") Long memberNo);
     Integer memberAssignTeam(@Param("memberNo") Long memberNo, @Param("teamNo") Long teamNo, @Param("beforeTeamNo") Integer beforeTeamNo);
+    Integer updateTaskMember(@Param("memberNo") Long memberNo, @Param("teamNo") Long teamNo, @Param("beforeTeamNo") Integer beforeTeamNo);
     int saveMember(MemberVO member);
     MemberVO findById(String username);
+    void disableTaskMemberConstraint();
+    void enableTaskMemberConstraint();
+    Integer updateFeatureMember(@Param("memberNo") Long memberNo, @Param("teamNo") Long teamNo, @Param("beforeTeamNo") Integer beforeTeamNo);
+    void disableFeatureMemberConstraint();
+    void enableFeatureMemberConstraint();
+    void bulkUpsertDate(@Param("type") String type, @Param("memberList") List<MemberStartFinishRequestDto> memberList);
+    void updateMembers(@Param("members") List<MemberUpdateRequestDto> members);
 }

--- a/src/main/java/com/kcc/pms/domain/member/model/dto/MemberResponseTCDto.java
+++ b/src/main/java/com/kcc/pms/domain/member/model/dto/MemberResponseTCDto.java
@@ -6,13 +6,12 @@ import lombok.Setter;
 import lombok.ToString;
 
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.List;
 
 @Getter
 @Setter
 @ToString
-public class MemberResponseDto implements Serializable {
+public class MemberResponseTCDto implements Serializable {
     private Long id;
     private String memberName;
     private String auth;
@@ -25,12 +24,6 @@ public class MemberResponseDto implements Serializable {
     private String tech;
     private String email;
     private String phoneNo;
-//    private Team connectTeam;
-    private Integer teamNo;
-    private Integer parentNo;
-    private String teamName;
-    private int orderNo;
-    private Integer systemNo;
-    private String teamContent;
-    private Long projectNo;
+    private List<Team> connectTeam;
+
 }

--- a/src/main/java/com/kcc/pms/domain/member/model/dto/MemberStartFinishRequestDto.java
+++ b/src/main/java/com/kcc/pms/domain/member/model/dto/MemberStartFinishRequestDto.java
@@ -1,0 +1,14 @@
+package com.kcc.pms.domain.member.model.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+public class MemberStartFinishRequestDto {
+    private Long id;
+    private String startDate;
+    private String endDate;
+}

--- a/src/main/java/com/kcc/pms/domain/member/model/dto/MemberTeamUpdateRequest.java
+++ b/src/main/java/com/kcc/pms/domain/member/model/dto/MemberTeamUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.kcc.pms.domain.member.model.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+public class MemberTeamUpdateRequest {
+    private Long memberId;
+    private Integer beforeTeamNo;
+}

--- a/src/main/java/com/kcc/pms/domain/member/model/dto/MemberUpdateRequestDto.java
+++ b/src/main/java/com/kcc/pms/domain/member/model/dto/MemberUpdateRequestDto.java
@@ -1,0 +1,17 @@
+package com.kcc.pms.domain.member.model.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+public class MemberUpdateRequestDto {
+    private Long id;
+    private String auth;
+    private String startDate;
+    private String endDate;
+    private String preStartDate;
+    private String preEndDate;
+}

--- a/src/main/java/com/kcc/pms/domain/member/service/MemberService.java
+++ b/src/main/java/com/kcc/pms/domain/member/service/MemberService.java
@@ -1,19 +1,20 @@
 package com.kcc.pms.domain.member.service;
 
-import com.kcc.pms.domain.member.model.dto.GroupMembersResponseDto;
-import com.kcc.pms.domain.member.model.dto.GroupResponseDto;
-import com.kcc.pms.domain.member.model.dto.MemberResponseDto;
-import com.kcc.pms.domain.member.model.dto.ProjectMemberResponseDto;
+import com.kcc.pms.domain.member.model.dto.*;
 import com.kcc.pms.domain.member.model.vo.MemberVO;
 
+import java.sql.SQLException;
+import java.sql.SQLIntegrityConstraintViolationException;
 import java.util.List;
 
 public interface MemberService {
     List<GroupResponseDto> getGroupList();
     List<GroupMembersResponseDto> getGroupMembers(Long groupNo);
     List<MemberResponseDto> getProjectMemberList(Long projectNo);
-    List<MemberResponseDto> getTeamMember(Long teamNo);
-    MemberResponseDto getMemberDetail(Long projectNo, Long memberNo);
-    Integer memberAssignTeam(Long memberNo, Long teamNo, Integer beforeTeamNo);
+    List<MemberResponseTCDto> getTeamMember(Long teamNo);
+    MemberResponseTCDto getMemberDetail(Long projectNo, Long memberNo);
+    Integer memberAssignTeam(Long memberNo, Long teamNo, Integer beforeTeamNo) throws SQLException;
+    void updateOrInsertDate(String type, List<MemberStartFinishRequestDto> updateList) throws SQLException;
+    void updateMembers(List<MemberUpdateRequestDto> members);
     int saveMember(MemberVO member);
 }

--- a/src/main/java/com/kcc/pms/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/kcc/pms/domain/member/service/MemberServiceImpl.java
@@ -1,16 +1,14 @@
 package com.kcc.pms.domain.member.service;
 
 import com.kcc.pms.domain.member.mapper.MemberMapper;
-import com.kcc.pms.domain.member.model.dto.GroupMembersResponseDto;
-import com.kcc.pms.domain.member.model.dto.GroupResponseDto;
-import com.kcc.pms.domain.member.model.dto.MemberResponseDto;
+import com.kcc.pms.domain.member.model.dto.*;
 
 
 import com.kcc.pms.domain.member.model.vo.MemberVO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
-
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -40,18 +38,71 @@ public class MemberServiceImpl implements MemberService{
     }
 
     @Override
-    public List<MemberResponseDto> getTeamMember(Long teamNo) {
+    public List<MemberResponseTCDto> getTeamMember(Long teamNo) {
         return mapper.getTeamMember(teamNo);
     }
 
     @Override
-    public MemberResponseDto getMemberDetail(Long projectNo, Long memberNo) {
+    public MemberResponseTCDto getMemberDetail(Long projectNo, Long memberNo) {
         return mapper.getMemberDetail(projectNo, memberNo);
     }
 
+    @Transactional(rollbackFor = Exception.class)
     @Override
-    public Integer memberAssignTeam(Long memberNo, Long teamNo, Integer beforeTeamNo) {
-        return mapper.memberAssignTeam(memberNo, teamNo, beforeTeamNo);
+    public Integer memberAssignTeam(Long memberNo, Long teamNo, Integer beforeTeamNo)  {
+        mapper.disableTaskMemberConstraint();
+        mapper.disableFeatureMemberConstraint();
+        try {
+            Integer result = mapper.memberAssignTeam(memberNo, teamNo, beforeTeamNo);
+            mapper.updateTaskMember(memberNo, teamNo, beforeTeamNo);
+            mapper.updateFeatureMember(memberNo, teamNo, beforeTeamNo);
+            return result;
+        } finally {
+            mapper.enableTaskMemberConstraint();
+            mapper.enableFeatureMemberConstraint();
+        }
+    }
+
+    @Override
+    public void updateOrInsertDate(String type, List<MemberStartFinishRequestDto> updateList){
+        mapper.bulkUpsertDate(type, updateList);
+    }
+
+    @Override
+    public void updateMembers(List<MemberUpdateRequestDto> members) {
+        for (MemberUpdateRequestDto member : members) {
+            if (member.getStartDate() != null) {
+                member.setStartDate(member.getStartDate().replace(" 00:00:00", ""));
+            }
+            if (member.getEndDate() != null) {
+                member.setEndDate(member.getEndDate().replace(" 00:00:00", ""));
+            }
+            if (member.getPreStartDate() != null) {
+                member.setPreStartDate(member.getPreStartDate().replace(" 00:00:00", ""));
+            }
+            if (member.getPreEndDate() != null) {
+                member.setPreEndDate(member.getPreEndDate().replace(" 00:00:00", ""));
+            }
+            switch (member.getAuth().trim()) {
+                case "PM":
+                    member.setAuth("PMS00201");
+                    break;
+                case "PL":
+                    member.setAuth("PMS00202");
+                    break;
+                case "팀원":
+                    member.setAuth("PMS00203");
+                    break;
+                case "사업관리자":
+                    member.setAuth("PMS00204");
+                    break;
+                case "고객":
+                    member.setAuth("PMS00205");
+                    break;
+            }
+        }
+        System.out.println("members = " + members);
+        mapper.updateMembers(members);
     }
 
     @Override

--- a/src/main/java/com/kcc/pms/domain/team/model/vo/Team.java
+++ b/src/main/java/com/kcc/pms/domain/team/model/vo/Team.java
@@ -2,11 +2,13 @@ package com.kcc.pms.domain.team.model.vo;
 
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 
 import java.io.Serializable;
 
 @Getter
 @Setter
+@ToString
 public class Team implements Serializable {
     private Integer teamNo;
     private Integer parentNo;

--- a/src/main/java/com/kcc/pms/domain/team/service/TeamServiceImpl.java
+++ b/src/main/java/com/kcc/pms/domain/team/service/TeamServiceImpl.java
@@ -2,6 +2,7 @@ package com.kcc.pms.domain.team.service;
 
 import com.kcc.pms.domain.member.mapper.MemberMapper;
 import com.kcc.pms.domain.member.model.dto.MemberResponseDto;
+import com.kcc.pms.domain.member.model.dto.MemberResponseTCDto;
 import com.kcc.pms.domain.team.mapper.TeamMapper;
 import com.kcc.pms.domain.team.model.dto.*;
 import com.kcc.pms.domain.team.model.vo.Team;
@@ -117,9 +118,9 @@ public class TeamServiceImpl implements TeamService{
 
     @Override
     public List<TeamMemberResponseDto> getTeamMembers(Long teamNo) {
-        List<MemberResponseDto> teamMember = memberMapper.getTeamMember(teamNo);
+        List<MemberResponseTCDto> teamMember = memberMapper.getTeamMember(teamNo);
         List<TeamMemberResponseDto> responseTeamMember = new ArrayList<>();
-        for (MemberResponseDto m : teamMember) {
+        for (MemberResponseTCDto m : teamMember) {
             TeamMemberResponseDto rm = new TeamMemberResponseDto();
             rm.setId(m.getId());
             rm.setMemberName(m.getMemberName());

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -722,39 +722,6 @@ INSERT INTO projectMember (mem_no, tm_no, prj_no, prj_auth_cd, pre_start_dt, pre
 VALUES (1, 1, 1, 'PMS00203', '2021-01-01', '2021-01-01', '2021-01-01', '2021-01-01', 'Y', 'user1', '2021-01-01', NULL, NULL);
 
 INSERT INTO projectMember (mem_no, tm_no, prj_no, prj_auth_cd, pre_start_dt, pre_end_dt, start_dt, end_dt, use_yn, reg_id, reg_dt, mod_id, mod_dt)
-VALUES (1, 1, 2, 'PMS00203', '2021-01-01', '2021-01-01', '2021-01-01', '2021-01-01', 'Y', 'user1', '2021-01-01', NULL, NULL);
-
-INSERT INTO projectMember (mem_no, tm_no, prj_no, prj_auth_cd, pre_start_dt, pre_end_dt, start_dt, end_dt, use_yn, reg_id, reg_dt, mod_id, mod_dt)
-VALUES (1, 1, 3, 'PMS00203', '2021-01-01', '2021-01-01', '2021-01-01', '2021-01-01', 'Y', 'user1', '2021-01-01', NULL, NULL);
-
-INSERT INTO projectMember (mem_no, tm_no, prj_no, prj_auth_cd, pre_start_dt, pre_end_dt, start_dt, end_dt, use_yn, reg_id, reg_dt, mod_id, mod_dt)
-VALUES (1, 1, 4, 'PMS00203', '2021-01-01', '2021-01-01', '2021-01-01', '2021-01-01', 'Y', 'user1', '2021-01-01', NULL, NULL);
-
-INSERT INTO projectMember (mem_no, tm_no, prj_no, prj_auth_cd, pre_start_dt, pre_end_dt, start_dt, end_dt, use_yn, reg_id, reg_dt, mod_id, mod_dt)
-VALUES (1, 1, 5, 'PMS00203', '2021-01-01', '2021-01-01', '2021-01-01', '2021-01-01', 'Y', 'user1', '2021-01-01', NULL, NULL);
-
-INSERT INTO projectMember (mem_no, tm_no, prj_no, prj_auth_cd, pre_start_dt, pre_end_dt, start_dt, end_dt, use_yn, reg_id, reg_dt, mod_id, mod_dt)
-VALUES (1, 1, 6, 'PMS00203', '2021-01-01', '2021-01-01', '2021-01-01', '2021-01-01', 'Y', 'user1', '2021-01-01', NULL, NULL);
-
-INSERT INTO projectMember (mem_no, tm_no, prj_no, prj_auth_cd, pre_start_dt, pre_end_dt, start_dt, end_dt, use_yn, reg_id, reg_dt, mod_id, mod_dt)
-VALUES (1, 1, 7, 'PMS00203', '2021-01-01', '2021-01-01', '2021-01-01', '2021-01-01', 'Y', 'user1', '2021-01-01', NULL, NULL);
-
-INSERT INTO projectMember (mem_no, tm_no, prj_no, prj_auth_cd, pre_start_dt, pre_end_dt, start_dt, end_dt, use_yn, reg_id, reg_dt, mod_id, mod_dt)
-VALUES (1, 1, 8, 'PMS00203', '2021-01-01', '2021-01-01', '2021-01-01', '2021-01-01', 'Y', 'user1', '2021-01-01', NULL, NULL);
-
-INSERT INTO projectMember (mem_no, tm_no, prj_no, prj_auth_cd, pre_start_dt, pre_end_dt, start_dt, end_dt, use_yn, reg_id, reg_dt, mod_id, mod_dt)
-VALUES (1, 1, 9, 'PMS00203', '2021-01-01', '2021-01-01', '2021-01-01', '2021-01-01', 'Y', 'user1', '2021-01-01', NULL, NULL);
-
-INSERT INTO projectMember (mem_no, tm_no, prj_no, prj_auth_cd, pre_start_dt, pre_end_dt, start_dt, end_dt, use_yn, reg_id, reg_dt, mod_id, mod_dt)
-VALUES (1, 1, 10, 'PMS00203', '2021-01-01', '2021-01-01', '2021-01-01', '2021-01-01', 'Y', 'user1', '2021-01-01', NULL, NULL);
-
-INSERT INTO projectMember (mem_no, tm_no, prj_no, prj_auth_cd, pre_start_dt, pre_end_dt, start_dt, end_dt, use_yn, reg_id, reg_dt, mod_id, mod_dt)
-VALUES (1, 1, 11, 'PMS00203', '2021-01-01', '2021-01-01', '2021-01-01', '2021-01-01', 'Y', 'user1', '2021-01-01', NULL, NULL);
-
-INSERT INTO projectMember (mem_no, tm_no, prj_no, prj_auth_cd, pre_start_dt, pre_end_dt, start_dt, end_dt, use_yn, reg_id, reg_dt, mod_id, mod_dt)
-VALUES (1, 1, 12, 'PMS00203', '2021-01-01', '2021-01-01', '2021-01-01', '2021-01-01', 'Y', 'user1', '2021-01-01', NULL, NULL);
-
-INSERT INTO projectMember (mem_no, tm_no, prj_no, prj_auth_cd, pre_start_dt, pre_end_dt, start_dt, end_dt, use_yn, reg_id, reg_dt, mod_id, mod_dt)
 VALUES (2, 1, 1, 'PMS00203', '2021-01-01', '2021-01-01', '2021-01-01', '2021-01-01', 'Y', 'user1', '2021-01-01', NULL, NULL);
 
 INSERT INTO projectMember (mem_no, tm_no, prj_no, prj_auth_cd, pre_start_dt, pre_end_dt, start_dt, end_dt, use_yn, reg_id, reg_dt, mod_id, mod_dt)
@@ -762,39 +729,6 @@ VALUES (3, 1, 1, 'PMS00202', '2021-01-01', '2021-01-01', '2021-01-01', '2021-01-
 
 INSERT INTO projectMember (mem_no, tm_no, prj_no, prj_auth_cd, pre_start_dt, pre_end_dt, start_dt, end_dt, use_yn, reg_id, reg_dt, mod_id, mod_dt)
 VALUES (14, 1, 1, 'PMS00201', '2021-01-01', '2021-01-01', '2021-01-01', '2021-01-01', 'Y', 'pm1', '2021-01-01', NULL, NULL);
-
-INSERT INTO projectMember (mem_no, tm_no, prj_no, prj_auth_cd, pre_start_dt, pre_end_dt, start_dt, end_dt, use_yn, reg_id, reg_dt, mod_id, mod_dt)
-VALUES (14, 1, 2, 'PMS00201', '2021-01-01', '2021-01-01', '2021-01-01', '2021-01-01', 'Y', 'pm1', '2021-01-01', NULL, NULL);
-
-INSERT INTO projectMember (mem_no, tm_no, prj_no, prj_auth_cd, pre_start_dt, pre_end_dt, start_dt, end_dt, use_yn, reg_id, reg_dt, mod_id, mod_dt)
-VALUES (14, 1, 3, 'PMS00201', '2021-01-01', '2021-01-01', '2021-01-01', '2021-01-01', 'Y', 'pm1', '2021-01-01', NULL, NULL);
-
-INSERT INTO projectMember (mem_no, tm_no, prj_no, prj_auth_cd, pre_start_dt, pre_end_dt, start_dt, end_dt, use_yn, reg_id, reg_dt, mod_id, mod_dt)
-VALUES (14, 1, 4, 'PMS00201', '2021-01-01', '2021-01-01', '2021-01-01', '2021-01-01', 'Y', 'pm1', '2021-01-01', NULL, NULL);
-
-INSERT INTO projectMember (mem_no, tm_no, prj_no, prj_auth_cd, pre_start_dt, pre_end_dt, start_dt, end_dt, use_yn, reg_id, reg_dt, mod_id, mod_dt)
-VALUES (14, 1, 5, 'PMS00201', '2021-01-01', '2021-01-01', '2021-01-01', '2021-01-01', 'Y', 'pm1', '2021-01-01', NULL, NULL);
-
-INSERT INTO projectMember (mem_no, tm_no, prj_no, prj_auth_cd, pre_start_dt, pre_end_dt, start_dt, end_dt, use_yn, reg_id, reg_dt, mod_id, mod_dt)
-VALUES (14, 1, 6, 'PMS00201', '2021-01-01', '2021-01-01', '2021-01-01', '2021-01-01', 'Y', 'pm1', '2021-01-01', NULL, NULL);
-
-INSERT INTO projectMember (mem_no, tm_no, prj_no, prj_auth_cd, pre_start_dt, pre_end_dt, start_dt, end_dt, use_yn, reg_id, reg_dt, mod_id, mod_dt)
-VALUES (14, 1, 7, 'PMS00201', '2021-01-01', '2021-01-01', '2021-01-01', '2021-01-01', 'Y', 'pm1', '2021-01-01', NULL, NULL);
-
-INSERT INTO projectMember (mem_no, tm_no, prj_no, prj_auth_cd, pre_start_dt, pre_end_dt, start_dt, end_dt, use_yn, reg_id, reg_dt, mod_id, mod_dt)
-VALUES (14, 1, 8, 'PMS00201', '2021-01-01', '2021-01-01', '2021-01-01', '2021-01-01', 'Y', 'pm1', '2021-01-01', NULL, NULL);
-
-INSERT INTO projectMember (mem_no, tm_no, prj_no, prj_auth_cd, pre_start_dt, pre_end_dt, start_dt, end_dt, use_yn, reg_id, reg_dt, mod_id, mod_dt)
-VALUES (14, 1, 9, 'PMS00201', '2021-01-01', '2021-01-01', '2021-01-01', '2021-01-01', 'Y', 'pm1', '2021-01-01', NULL, NULL);
-
-INSERT INTO projectMember (mem_no, tm_no, prj_no, prj_auth_cd, pre_start_dt, pre_end_dt, start_dt, end_dt, use_yn, reg_id, reg_dt, mod_id, mod_dt)
-VALUES (14, 1, 10, 'PMS00201', '2021-01-01', '2021-01-01', '2021-01-01', '2021-01-01', 'Y', 'pm1', '2021-01-01', NULL, NULL);
-
-INSERT INTO projectMember (mem_no, tm_no, prj_no, prj_auth_cd, pre_start_dt, pre_end_dt, start_dt, end_dt, use_yn, reg_id, reg_dt, mod_id, mod_dt)
-VALUES (14, 1, 11, 'PMS00201', '2021-01-01', '2021-01-01', '2021-01-01', '2021-01-01', 'Y', 'pm1', '2021-01-01', NULL, NULL);
-
-INSERT INTO projectMember (mem_no, tm_no, prj_no, prj_auth_cd, pre_start_dt, pre_end_dt, start_dt, end_dt, use_yn, reg_id, reg_dt, mod_id, mod_dt)
-VALUES (14, 1, 12, 'PMS00201', '2021-01-01', '2021-01-01', '2021-01-01', '2021-01-01', 'Y', 'pm1', '2021-01-01', NULL, NULL);
 
 INSERT INTO System (sys_no, sys_ttl, sys_cont, use_yn, prj_no, par_sys_no, sys_yn)
 VALUES (seq_system.nextval, 'A 업무 시스템', '시스템1 내용', 'Y', 1, NULL, 'Y');

--- a/src/main/resources/mapper/MemberMapper.xml
+++ b/src/main/resources/mapper/MemberMapper.xml
@@ -23,7 +23,7 @@
 
 
 
-    <resultMap id="memberDetail" type="com.kcc.pms.domain.member.model.dto.MemberResponseDto">
+    <resultMap id="memberDetail" type="com.kcc.pms.domain.member.model.dto.MemberResponseTCDto">
         <id column="MEM_NO" property="id" />
         <result column="MEM_NM" property="memberName" />
         <result column="AUTH" property="auth" />
@@ -37,33 +37,33 @@
         <result column="EMAIL" property="email" />
         <result column="PHONE_NO" property="phoneNo" />
 
-        <collection property="connectTeams" resultMap="connectTeams"/>
+        <collection property="connectTeam" resultMap="connectTeam"/>
     </resultMap>
 
-    <resultMap id="connectTeams" type="com.kcc.pms.domain.team.model.vo.Team">
+    <resultMap id="connectTeam" type="com.kcc.pms.domain.team.model.vo.Team">
         <result column="TM_NO" property="teamNo" />
         <result column="TM_NM" property="teamName" />
         <result column="ORDER_NO" property="orderNo"/>
         <result column="PAR_TM_NO" property="parentNo"/>
     </resultMap>
 
-    <select id="getProjectMemberList" resultMap="memberDetail">
-        SELECT m.mem_no,
-               m.mem_nm,
+    <select id="getProjectMemberList" resultType="com.kcc.pms.domain.member.model.dto.MemberResponseDto">
+        SELECT m.mem_no as id,
+               m.mem_nm as memberName,
                auth.cd_dtl_nm AS AUTH,
-               g.grp_nm,
+               g.grp_nm as groupName,
                pos.cd_dtl_nm AS POSITION,
-               pm.pre_start_dt,
-               pm.pre_end_dt,
-               pm.start_dt,
-               pm.end_dt,
-               m.email,
-               m.phone_no,
+               pm.pre_start_dt as preStartDate,
+               pm.pre_end_dt as preEndDate,
+               pm.start_dt as startDate,
+               pm.end_dt as endDate,
+               m.email as email,
+               m.phone_no as phoneNo,
                tech.cd_dtl_nm AS TECH,
-               t.tm_nm,
-               t.tm_no,
-               t.order_no,
-               t.par_tm_no
+               t.tm_nm as teamName,
+               t.tm_no as teamNo,
+               t.order_no as orderNo,
+               t.par_tm_no as parentNo
         FROM projectmember pm,
              member m,
              usergroup g,
@@ -119,22 +119,22 @@
 
 
 
-    <select id="getTeamMember" resultMap="memberDetail">
-        SELECT m.mem_no,
-               m.mem_nm,
+    <select id="getTeamMember" resultType="com.kcc.pms.domain.member.model.dto.MemberResponseDto">
+        SELECT m.mem_no AS id,
+               m.mem_nm AS memberName,
                auth.cd_dtl_nm as AUTH,
-               gr.grp_nm,
+               gr.grp_nm AS groupName,
                pos.cd_dtl_nm as POSITION,
-               pm.pre_start_dt,
-               pm.pre_end_dt,
-               pm.start_dt,
-               pm.end_dt,
-               tech.cd_dtl_nm as TECH,
-               m.email,
-               m.phone_no,
-               t.tm_no,
-               t.tm_nm,
-               t.order_no
+               pm.pre_start_dt AS preStartDate,
+               pm.pre_end_dt AS preEndDate,
+               pm.start_dt AS startDate,
+               pm.end_dt AS endDate,
+               tech.cd_dtl_nm AS tech,
+               m.email AS email,
+               m.phone_no AS phoneNo,
+               t.tm_no AS teamNo,
+               t.tm_nm AS teamName,
+               t.order_no AS orderNo
         FROM projectmember pm,
              member m,
              usergroup gr,
@@ -151,8 +151,41 @@
             t.tm_no = #{teamNo}
     </select>
 
+    <update id="updateTaskMember">
+        UPDATE TaskMember
+        SET tm_no = #{teamNo}
+        WHERE mem_no = #{memberNo}
+          AND tm_no = #{beforeTeamNo}
+    </update>
+
+    <update id="updateFeatureMember">
+        UPDATE Feature
+        SET tm_no = #{teamNo}
+        WHERE mem_no = #{memberNo}
+          AND tm_no = #{beforeTeamNo}
+    </update>
+
+    <update id="disableTaskMemberConstraint">
+        ALTER TABLE TaskMember DISABLE CONSTRAINT fk_tsk_mem_no_002
+    </update>
+
+    <update id="enableTaskMemberConstraint">
+        ALTER TABLE TaskMember ENABLE CONSTRAINT fk_tsk_mem_no_002
+    </update>
+
+    <update id="disableFeatureMemberConstraint">
+        ALTER TABLE Feature DISABLE CONSTRAINT FK_PROJECTMEMBER_TO_FEATURE
+    </update>
+
+        <update id="enableFeatureMemberConstraint">
+        ALTER TABLE Feature ENABLE CONSTRAINT FK_PROJECTMEMBER_TO_FEATURE
+    </update>
+
     <update id="memberAssignTeam">
-        UPDATE projectmember SET tm_no = #{teamNo} WHERE mem_no = #{memberNo} and tm_no = #{beforeTeamNo}
+        UPDATE ProjectMember
+        SET tm_no = #{teamNo}
+        WHERE mem_no = #{memberNo}
+        AND tm_no = #{beforeTeamNo}
     </update>
 
     <insert id="saveMember">
@@ -182,6 +215,34 @@
         from member
         where login_id = #{username}
     </select>
+
+
+    <update id="bulkUpsertDate">
+        <foreach collection="memberList" item="member" open="DECLARE BEGIN" separator=";" close="; END;">
+            UPDATE projectmember
+            SET
+            <if test="type == 'start'">
+                start_dt = #{member.startDate}
+            </if>
+            <if test="type == 'end'">
+                end_dt = #{member.endDate}
+            </if>
+            WHERE mem_no = #{member.id}
+        </foreach>
+    </update>
+
+    <update id="updateMembers">
+        <foreach collection="members" item="member" open="DECLARE BEGIN" separator=";" close="; END;">
+            UPDATE projectmember
+            SET
+            prj_auth_cd = #{member.auth,jdbcType=VARCHAR},
+            start_dt = #{member.startDate,jdbcType=DATE},
+            end_dt = #{member.endDate,jdbcType=DATE},
+            pre_start_dt = #{member.preStartDate,jdbcType=DATE},
+            pre_end_dt = #{member.preEndDate,jdbcType=DATE}
+            WHERE mem_no = #{member.id}
+        </foreach>
+    </update>
 
 </mapper>
 

--- a/src/main/webapp/WEB-INF/views/danger/danger_list.jsp
+++ b/src/main/webapp/WEB-INF/views/danger/danger_list.jsp
@@ -22,7 +22,7 @@
         </div>
 
         <div class="filter-section">
-            <form action="#" method="post">
+            <form action="#" method="post" class="search_form">
                 <input type="hidden" name="systemNo" id="systemNo">
                 시스템 분류&nbsp;&nbsp;
                 <div class="system-select-wrapper">
@@ -46,10 +46,11 @@
                 <select id="PMS006" name="priorCode" required>
                     <option value="">전체분류</option>
                 </select>
-                <form action="#" method="post">
+
+                <span class="search-area">
                     <input id="riskSearchName" type="text" name="title" class="search-text" placeholder="위험명을 검색하세요">
                     <button id="riskSearchBtn" type="submit" class="search" value="">검색</button>
-                </form>
+                </span>
             </form>
         </div>
 

--- a/src/main/webapp/WEB-INF/views/danger/info.jsp
+++ b/src/main/webapp/WEB-INF/views/danger/info.jsp
@@ -14,6 +14,8 @@
         rel="stylesheet"
 />
 <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
+<script src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"></script>
+<link rel="stylesheet" href="https://code.jquery.com/ui/1.13.2/themes/smoothness/jquery-ui.css">
 <link rel="stylesheet" href="../../../resources/issue/css/info.css">
 <script src="https://cdnjs.cloudflare.com/ajax/libs/dropzone/5.9.3/min/dropzone.min.js"></script>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/dropzone/5.9.3/min/dropzone.min.css" />
@@ -52,7 +54,7 @@
 
                         <table class="overview-table">
                             <tr>
-                                <td class="text-align-left">
+                                <td class="td-row">
                                     <label for="riskTitle">제목 <span class="required-icon">*</span></label>
                                 </td>
                                 <td colspan="5">
@@ -60,31 +62,31 @@
                                 </td>
                             </tr>
                             <tr>
-                                <td class="text-align-left">
+                                <td class="td-row">
                                     <label for="riskId">위험 ID <span class="required-icon">*</span></label>
                                 </td>
-                                <td class="td-row">
+                                <td class="text-align-left">
                                     <input type="text" id="riskId" name="riskId" value="" required>
                                 </td>
-                                <td class="text-align-left">
+                                <td class="td-row">
                                     <label>위험분류 <span class="required-icon">*</span></label>
                                 </td>
-                                <td class="td-row">
+                                <td class="text-align-left">
                                     <select id="PMS005" name="classCode" required>
                                         <option value="">선택하세요.</option>
                                     </select>
                                 </td>
-                                <td class="text-align-left">
+                                <td class="td-row">
                                     <label>우선순위 <span class="required-icon">*</span></label>
                                 </td>
-                                <td class="td-row">
+                                <td class="td-row-active">
                                     <select id="PMS006" name="priorCode" required>
                                         <option value="">선택하세요.</option>
                                     </select>
                                 </td>
                             </tr>
                             <tr>
-                                <td class="text-align-left">
+                                <td class="td-row">
                                     <label>시스템/업무</label>
                                 </td>
                                 <td colspan="3">
@@ -97,7 +99,7 @@
                                         <ul class="mymenu" id="system-menu"></ul>
                                     </div>
                                 </td>
-                                <td class="text-align-left">
+                                <td class="td-row">
                                     <label>위험상태 <span class="required-icon">*</span></label>
                                 </td>
                                 <td>
@@ -107,7 +109,7 @@
                                 </td>
                             </tr>
                             <tr>
-                                <td class="text-align-left">
+                                <td class="td-row">
                                     <label for="riskContent">위험내용 <span class="required-icon">*</span></label>
                                 </td>
                                 <td colspan="5">
@@ -115,7 +117,7 @@
                                 </td>
                             </tr>
                             <tr>
-                                <td class="text-align-left">
+                                <td class="td-row">
                                     <label for="riskPlan">위험완화계획 </label>
                                 </td>
                                 <td colspan="5">
@@ -123,19 +125,19 @@
                                 </td>
                             </tr>
                             <tr>
-                                <td class="text-align-left">
+                                <td class="td-row">
                                     <label for="dueDate">조치희망일 <span class="required-icon">*</span></label>
                                 </td>
                                 <td>
-                                    <input type="date" id="dueDate" name="dueDate" value="" required>
+                                    <input type="text" id="dueDate" name="dueDate" value="" placeholder="yyyy-mm-dd" required>
                                 </td>
-                                <td class="text-align-left">
+                                <td class="td-row">
                                     <label for="completeDate">조치완료일</label>
                                 </td>
                                 <td>
-                                    <input type="date" id="completeDate" name="completeDate" value="">
+                                    <input type="text" id="completeDate" name="completeDate" placeholder="yyyy-mm-dd" value="">
                                 </td>
-                                <td class="text-align-left">
+                                <td class="td-row">
                                     <label for="memberNo">발견자 <span class="required-icon">*</span></label>
                                 </td>
                                 <td>

--- a/src/main/webapp/WEB-INF/views/issue/info.jsp
+++ b/src/main/webapp/WEB-INF/views/issue/info.jsp
@@ -14,6 +14,8 @@
         rel="stylesheet"
 />
 <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
+<script src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"></script>
+<link rel="stylesheet" href="https://code.jquery.com/ui/1.13.2/themes/smoothness/jquery-ui.css">
 <link rel="stylesheet" href="../../../resources/issue/css/info.css">
 <script src="https://cdnjs.cloudflare.com/ajax/libs/dropzone/5.9.3/min/dropzone.min.js"></script>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/dropzone/5.9.3/min/dropzone.min.css" />
@@ -52,7 +54,7 @@
 
                         <table class="overview-table">
                             <tr>
-                                <td class="text-align-left">
+                                <td class="td-row">
                                     <label for="riskTitle">제목 <span class="required-icon">*</span></label>
                                 </td>
                                 <td colspan="5">
@@ -60,31 +62,31 @@
                                 </td>
                             </tr>
                             <tr>
-                                <td class="text-align-left">
+                                <td class="td-row">
                                     <label for="riskId">이슈 ID <span class="required-icon">*</span></label>
                                 </td>
-                                <td class="td-row">
+                                <td class="td-row-active">
                                     <input type="text" id="riskId" name="riskId" value="" required>
                                 </td>
-                                <td class="text-align-left">
+                                <td class="td-row">
                                     <label>이슈분류 <span class="required-icon">*</span></label>
                                 </td>
-                                <td class="td-row">
+                                <td class="td-row-active">
                                     <select id="PMS005" name="classCode" required>
                                         <option value="">선택하세요.</option>
                                     </select>
                                 </td>
-                                <td class="text-align-left">
+                                <td class="td-row">
                                     <label>우선순위 <span class="required-icon">*</span></label>
                                 </td>
-                                <td class="td-row">
+                                <td class="td-row-active">
                                     <select id="PMS006" name="priorCode" required>
                                         <option value="">선택하세요.</option>
                                     </select>
                                 </td>
                             </tr>
                             <tr>
-                                <td class="text-align-left">
+                                <td class="td-row">
                                     <label>시스템/업무</label>
                                 </td>
                                 <td colspan="3">
@@ -97,7 +99,7 @@
                                         <ul class="mymenu" id="system-menu"></ul>
                                     </div>
                                 </td>
-                                <td class="text-align-left">
+                                <td class="td-row">
                                     <label>이슈상태 <span class="required-icon">*</span></label>
                                 </td>
                                 <td>
@@ -107,7 +109,7 @@
                                 </td>
                             </tr>
                             <tr>
-                                <td class="text-align-left">
+                                <td class="td-row">
                                     <label for="riskContent">이슈내용 <span class="required-icon">*</span></label>
                                 </td>
                                 <td colspan="5">
@@ -116,19 +118,19 @@
                             </tr>
 
                             <tr>
-                                <td class="text-align-left">
+                                <td class="td-row">
                                     <label for="dueDate">조치희망일 <span class="required-icon">*</span></label>
                                 </td>
                                 <td>
-                                    <input type="date" id="dueDate" name="dueDate" value="" required>
+                                    <input type="text" id="dueDate" name="dueDate" placeholder="yyyy-mm-dd" required>
                                 </td>
-                                <td class="text-align-left">
+                                <td class="td-row">
                                     <label for="completeDate">조치완료일</label>
                                 </td>
                                 <td>
-                                    <input type="date" id="completeDate" name="completeDate" value="">
+                                    <input type="text" id="completeDate" name="completeDate" placeholder="yyyy-mm-dd">
                                 </td>
-                                <td class="text-align-left">
+                                <td class="td-row">
                                     <label for="memberNo">발견자 <span class="required-icon">*</span></label>
                                 </td>
                                 <td>
@@ -203,7 +205,7 @@
 
                                 <div>
                                     <label for="record_dt">조치일자</label>
-                                    <input type="date" id="record_dt" name="record_dt" class="form-control" required>
+                                    <input type="text" id="record_dt" name="record_dt" class="form-control" placeholder="yyyy-mm-dd" required>
                                 </div>
                                 <label for="record_cont" class="form-label">조치내용</label>
                                 <textarea id="record_cont" name="record_cont" class="form-control" rows="4" placeholder="조치 내용을 입력하세요"></textarea>

--- a/src/main/webapp/WEB-INF/views/issue/list.jsp
+++ b/src/main/webapp/WEB-INF/views/issue/list.jsp
@@ -22,7 +22,7 @@
         </div>
 
         <div class="filter-section">
-            <form action="#" method="post">
+            <form action="#" method="post" class="search_form">
                 <input type="hidden" name="systemNo" id="systemNo">
                 시스템 분류&nbsp;&nbsp;
                 <div class="system-select-wrapper">
@@ -46,10 +46,10 @@
                 <select id="PMS006" name="priorCode" required>
                     <option value="">전체분류</option>
                 </select>
-                <form action="#" method="post">
+                <span class="search-area">
                     <input id="riskSearchName" type="text" name="title" class="search-text" placeholder="이슈명을 검색하세요">
                     <button id="riskSearchBtn" type="submit" class="search" value="">검색</button>
-                </form>
+                </span>
             </form>
         </div>
 

--- a/src/main/webapp/WEB-INF/views/member/list.jsp
+++ b/src/main/webapp/WEB-INF/views/member/list.jsp
@@ -13,7 +13,11 @@
 <link rel="stylesheet" href="https://code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
 <link rel="stylesheet" href="../../../resources/member/css/list.css">
 <link rel="stylesheet" href="../../../resources/common/css/ax5gridMin.css">
-
+<link
+        href="https://cdn.jsdelivr.net/npm/sweetalert2@11/dist/sweetalert2.min.css"
+        rel="stylesheet"
+/>
+<script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
 
 <main class="content" id="content">
     <div class="main_content">
@@ -58,7 +62,7 @@
                         <div class="team-title">전체 투입 인력 목록</div>
                         <div class="btn-group">
                             <button class="">삭제</button>
-                            <button class="member-edit-button">편집</button>
+                            <button id="projectMemberUpdateBtn" class="member-edit-button">저장</button>
                             <button class="" onclick="openGroupPopup()">인력등록</button>
                         </div>
                     </div>
@@ -168,14 +172,14 @@
                     <div class="team-overview-title">
                         <div class="team-title">팀원 목록</div>
                         <div class="btn-group">
-                            <button class="">참여시작</button>
-                            <button class="">참여종료</button>
+                            <button id="startProject" class="">참여시작</button>
+                            <button id="endProject" class="">참여종료</button>
                             <button class="">해제</button>
-                            <button class="member-edit-button">편집</button>
+                            <button id="teamMemberUpdateBtn" class="member-edit-button">저장</button>
                             <button class="" onclick="openGroupPopup()">인력등록</button>
                         </div>
                     </div>
-                    <div style="position: relative;height:270px;" id="grid-parent">
+                    <div style="position: relative;height:200px;" id="grid-parent">
                         <div data-ax5grid="teamMemberGrid" data-ax5grid-config="{}" style="height: 100%;"></div>
                     </div>
                 </div>
@@ -183,10 +187,7 @@
                 <div class="member-detail">
                     <div class="team-overview-title">
                         <div class="team-title">인력 상세</div>
-                        <div class="btn-group">
-                            <button class="">수정</button>
-                            <button class="">해제</button>
-                        </div>
+
                     </div>
                     <table class="detail-table">
                         <tr>

--- a/src/main/webapp/WEB-INF/views/member/memberRegister.jsp
+++ b/src/main/webapp/WEB-INF/views/member/memberRegister.jsp
@@ -77,7 +77,7 @@
             </div>
         </div>
 
-        <div style="position: relative;height:270px;" id="grid-parent3">
+        <div style="position: relative;height:200px;" id="grid-parent3">
             <div id="y-added-grid" data-ax5grid="added-grid" data-ax5grid-config="{}" style="height: 100%;"></div>
         </div>
     </div>
@@ -112,7 +112,7 @@
             </div>
         </div>
 
-        <div style="position: relative;height:270px;" id="grid-parent2">
+        <div style="position: relative;height:200px;" id="grid-parent2">
             <!--<div class="y-added-grid"  data-ax5grid="added-grid" data-ax5grid-config="{}" style="height: 100%;"></div>-->
         </div>
     </div>

--- a/src/main/webapp/resources/common/css/common.css
+++ b/src/main/webapp/resources/common/css/common.css
@@ -282,7 +282,7 @@ body {
 
 .main_content {
     background-color: white;
-    height: 95%;
+    height: 85%;
     margin: 90px 25px 50px 25px;
 }
 

--- a/src/main/webapp/resources/danger/css/danger.css
+++ b/src/main/webapp/resources/danger/css/danger.css
@@ -205,3 +205,11 @@ h5 {
 .system-select-button:focus {
     outline: none;
 }
+
+.search_form {
+    width: 100%;
+}
+
+.search-area {
+   float: right;
+}

--- a/src/main/webapp/resources/danger/js/info.js
+++ b/src/main/webapp/resources/danger/js/info.js
@@ -5,6 +5,10 @@ let dropzone1;
 let riskNo;
 let historyDropzone;
 document.addEventListener('DOMContentLoaded', function() {
+    $("#record_dt, #dueDate, #completeDate").datepicker({
+        dateFormat: "yy-mm-dd"  // 원하는 형식으로 날짜 표시
+    });
+
     const statusSelect = document.getElementById('PMS004');
     const completionDateField = document.getElementById('completeDate');
 

--- a/src/main/webapp/resources/issue/css/info.css
+++ b/src/main/webapp/resources/issue/css/info.css
@@ -82,6 +82,11 @@ input[type="text"] {
 }
 
 .td-row {
+    width: 13%;
+    background-color: #EDF0F5;
+}
+
+.td-row-active {
     width: 18%;
 }
 
@@ -370,7 +375,7 @@ input:disabled, select:disabled, textarea:disabled {
 
 .text-align-left {
     text-align: left;
-    background-color: #EDF0F5;
+
     font-weight: bold;
     width: 110px !important;
     padding-top: 5px;
@@ -548,6 +553,7 @@ input:disabled, select:disabled, textarea:disabled {
 .system-select-wrapper {
     display: inline-block;
     position: relative;
+    width: 100%;
 }
 
 .system-select-label {
@@ -561,7 +567,7 @@ input:disabled, select:disabled, textarea:disabled {
     cursor: pointer;
     border: 1px solid #ccc;
     background-color: #fff;
-    width: 377px;
+    width: 100%;
     height: 38px;
     border-radius: 4px;
     text-align: left;

--- a/src/main/webapp/resources/issue/js/info.js
+++ b/src/main/webapp/resources/issue/js/info.js
@@ -5,6 +5,10 @@ let dropzone1;
 let riskNo;
 let historyDropzone;
 document.addEventListener('DOMContentLoaded', function() {
+    $("#record_dt, #dueDate, #completeDate").datepicker({
+        dateFormat: "yy-mm-dd"  // 원하는 형식으로 날짜 표시
+    });
+
     const statusSelect = document.getElementById('PMS004');
     const completionDateField = document.getElementById('completeDate');
 

--- a/src/main/webapp/resources/member/css/memberRegister.css
+++ b/src/main/webapp/resources/member/css/memberRegister.css
@@ -100,7 +100,7 @@ body {
 
 .addedMembersList {
     width: 900px;
-    height: 400px;
+    height: 285px;
 
 }
 

--- a/src/main/webapp/resources/member/js/memberRegisterGrid.js
+++ b/src/main/webapp/resources/member/js/memberRegisterGrid.js
@@ -88,7 +88,7 @@ $(document.body).ready(function () {
                 console.log(member.preEndDate);
                 console.log(member.startDate);
                 console.log(member.endDate);
-                console.log(member.connectTeams);
+                console.log(member.connectTeam);
                 addedMembers.push({
                     id: member.id,
                     name: member.memberName,
@@ -100,7 +100,9 @@ $(document.body).ready(function () {
                     st_dt: member.startDate ? member.startDate : "",
                     end_dt: member.endDate ? member.endDate : "",
                     techGrade: member.tech,
-                    connectTeams: member.connectTeams
+                    connectTeam: member.connectTeam,
+                    teamNo: member.teamNo,
+                    parentNo: member.parentNo
                 });
 
             }
@@ -124,7 +126,11 @@ $(document.body).ready(function () {
     initGrid();
     reg_loadProjectMember();
 
-    //$('#add-member-by-prjmem').hide();
+    setTimeout(function() {
+        $('#add-member-by-prjmem').hide();
+    },300);
+
+
 
     checkProject();
 });
@@ -209,9 +215,9 @@ function initGrid() {
         showRowSelector: true,
         target: $('[data-ax5grid="groupmemGrid"]'),
         columns: [
-            {key: "memberName", label: "성명", align: "center"},
+            {key: "memberName", width:70, label: "성명", align: "center"},
             {key: "position", label: "직위", align: "center" },
-            {key: "email", width: 220, label: "이메일", align: "center"},
+            {key: "email", width: 230, label: "이메일", align: "center"},
             {key: "participate_yn", width: 70, label: "참여여부",align: "center"},
             {key: "tech", width: 70, label: "기술등급",align: "center"}
         ],
@@ -232,15 +238,8 @@ function initGrid() {
             {key: "position", width: 80, label: "직위", align: "center"},
             {key: "tech", width: 80, label: "기술등급", align: "center"},
             {key: "teamName", width: 110, label: "소속팀", align: "center", formatter: function() {
-                    // connectedTeams을 탐색하면서 소속된 팀들 모두 가져옴
-                    if (this.item.connectTeams && this.item.connectTeams.length > 0) {
-                        // 소속팀이 하나뿐이고 parentNo이 null인 경우
-                        if (this.item.connectTeams.length === 1 && this.item.connectTeams[0].parentNo === null) {
-                            return '-'; // 소속팀이 없음을 표시
-                        }
-                        return this.item.connectTeams.map(function(team) {
-                            return team.teamName;
-                        }).join(', '); // 팀 이름을 ', '로 구분하여 표시
+                    if (this.item.parentNo != null) {
+                        return this.item.teamName;
                     } else {
                         return '-';
                     }
@@ -250,7 +249,13 @@ function initGrid() {
                     config: {
                         content: {
                             config: {
-                                mode: "year", selectMode: "day"
+                                mode: "year",
+                                selectMode: "day",
+                                // 기본 포커스 날짜 설정
+                                defaultDate: function() {
+                                    // 값이 2999-12-31이면 현재 날짜로 기본 포커스 설정
+                                    return this.value.substring(0, 10)  === '2999-12-31' ? new Date() : this.value;
+                                }
                             }
                         }
                     },
@@ -265,7 +270,13 @@ function initGrid() {
                     config: {
                         content: {
                             config: {
-                                mode: "year", selectMode: "day"
+                                mode: "year",
+                                selectMode: "day",
+                                // 기본 포커스 날짜 설정
+                                defaultDate: function() {
+                                    // 값이 2999-12-31이면 현재 날짜로 기본 포커스 설정
+                                    return this.value.substring(0, 10)  === '2999-12-31' ? new Date() : this.value;
+                                }
                             }
                         }
                     },
@@ -280,7 +291,13 @@ function initGrid() {
                     config: {
                         content: {
                             config: {
-                                mode: "year", selectMode: "day"
+                                mode: "year",
+                                selectMode: "day",
+                                // 기본 포커스 날짜 설정
+                                defaultDate: function() {
+                                    // 값이 2999-12-31이면 현재 날짜로 기본 포커스 설정
+                                    return this.value.substring(0, 10)  === '2999-12-31' ? new Date() : this.value;
+                                }
                             }
                         }
                     },
@@ -295,7 +312,13 @@ function initGrid() {
                     config: {
                         content: {
                             config: {
-                                mode: "year", selectMode: "day"
+                                mode: "year",
+                                selectMode: "day",
+                                // 기본 포커스 날짜 설정
+                                defaultDate: function() {
+                                    // 값이 2999-12-31이면 현재 날짜로 기본 포커스 설정
+                                    return this.value.substring(0, 10)  === '2999-12-31' ? new Date() : this.value;
+                                }
                             }
                         }
                     },
@@ -413,7 +436,7 @@ function initGrid() {
                         }
 
                 },
-                {key: "techGrade", width: 70, label: "기술등급", align: "center"}
+                {key: "techGrade", width: 85, label: "기술등급", align: "center"}
             ],
             page: {
                 display: false
@@ -435,6 +458,7 @@ async function registerMember() {
     console.log("register call addedMembers" + addedMembers);
     loadAuthCommonCode().then(async function(commonCodeOptions) {
         addedMembers.map(function(member) {
+            console.log(addedMembers);
             console.log(JSON.stringify(member));
             var authCode = member.auth;
             var selectedOption = commonCodeOptions.find(function(option) {
@@ -451,12 +475,18 @@ async function registerMember() {
                 pre_end_dt: member.preEndDate ? member.preEndDate : null,
                 st_dt: member.startDate ? member.startDate : null,
                 end_dt: member.endDate ? member.endDate : null,
-                connectFirstTeamNo: member.connectTeams ? member.connectTeams[0].teamNo : null
+                connectFirstTeamNo: member.teamNo ? member.teamNo : null
             };
 
-            if (member.connectTeams && member.connectTeams.length === 1 && member.connectTeams[0].parentNo === null) {
+            console.log("!!!!");
+            console.log(member);
+            if (member.parentNo === null) {
                 unassignedMembers.push(memberData);
-            } else {
+            } else if (member.teamNo == null){
+                assignedMembers.push(memberData);
+                console.log("AAAAAAAAAAAAAAAAAAAA");
+            }
+            else {
                 assignedMembers.push(memberData);
             }
         });
@@ -465,6 +495,8 @@ async function registerMember() {
             let assignedMembersPromise = Promise.resolve();  // 기본값으로 비어있는 Promise 생성
 
             if (assignedMembers.length > 0) {
+                alert("assignedMembers");
+                alert(assignedMembers);
                 assignedMembersPromise = $.ajax({
                     url: '/team/' + teamNo + '/members?prjNo=' + prjNo,
                     type: 'POST',
@@ -480,6 +512,8 @@ async function registerMember() {
             let unassignedMembersPromise = Promise.resolve();  // 기본값으로 비어있는 Promise 생성
 
             if (unassignedMembers.length > 0) {
+                alert("unassignedMembers")
+                alert(unassignedMembers);
                 // 모든 비배정 팀원의 팀 배정 요청을 저장할 배열
                 const requests = unassignedMembers.map(memberData => {
                     console.log("update" + memberData.id);


### PR DESCRIPTION
# 작업 내용
- 소속팀 변경 시 드래그 앤 드롭 -> 기존 1명 제한을 여러명으로 확대
- 소속팀 변경 시 같은 인원이 있다면 예외처리 (sweetAlert 라이브러리 사용)
- 여러명 선택 후 일괄 참여시작 및 참여종료일 설정
- 그리드 내에서 프로젝트권한 및 날짜 변경 가능
- 인력등록 팝업페이지 사이즈 조절(스크롤x)
- 기존에 인력등록 팝업페이지 처음 랜더링 시  '목록찾기' UI가 나오는 문제 및 레이아웃 깨짐 해결
- 날짜필드가 NULL 이면 2999-12-31이 editor에서 나오는 문제 해결
- 더미 데이터 팀 변경 시 무결성 오류 해결  

# To Reviewers

# Screen Shot (선택)

# Issue
- resolved: #258
